### PR TITLE
Add vistara vendor command to read DDR temperature

### DIFF
--- a/cxl/builtin.h
+++ b/cxl/builtin.h
@@ -122,4 +122,5 @@ int cmd_pcie_eye_status(int argc, const char **argv, struct cxl_ctx *ctx);
 int cmd_pcie_eye_get(int argc, const char **argv, struct cxl_ctx *ctx);
 int cmd_get_cxl_link_status(int argc, const char **argv, struct cxl_ctx *ctx);
 int cmd_get_device_info(int argc, const char **argv, struct cxl_ctx *ctx);
+int cmd_read_ddr_temp(int argc, const char **argv, struct cxl_ctx *ctx);
 #endif /* _CXL_BUILTIN_H_ */

--- a/cxl/cxl.c
+++ b/cxl/cxl.c
@@ -178,6 +178,7 @@ static struct cmd_struct commands[] = {
 	{ "pcie-eye-get", .c_fn = cmd_pcie_eye_get },
 	{ "get-cxl-link-status", .c_fn = cmd_get_cxl_link_status },
 	{ "get-device-info", .c_fn = cmd_get_device_info },
+	{ "read-ddr-temp", .c_fn = cmd_read_ddr_temp },
 };
 
 int main(int argc, const char **argv)

--- a/cxl/lib/libcxl.c
+++ b/cxl/lib/libcxl.c
@@ -10647,6 +10647,46 @@ out:
 #define CXL_MEM_COMMAND_ID_GET_CXL_LINK_STATUS CXL_MEM_COMMAND_ID_RAW
 #define CXL_MEM_COMMAND_ID_GET_CXL_LINK_STATUS_OPCODE 0xFB07
 
+char ltssm_state_name[][20] =
+{
+	"DETECT_QUIET",
+	"DETECT_ACT",
+	"POLL_ACTIVE",
+	"POLL_COMPLIANCE",
+	"POLL_CONFIG",
+	"PRE_DETECT_QUIET",
+	"DETECT_WAIT",
+	"CFG_LINKWD_START",
+	"CFG_LINKWD_ACEPT",
+	"CFG_LANENUM_WAIT",
+	"CFG_LANENUM_ACEPT",
+	"CFG_COMPLETE",
+	"CFG_IDLE",
+	"RCVRY_LOCK",
+	"RCVRY_SPEED",
+	"RCVRY_RCVRCFG",
+	"RCVRY_IDLE",
+	"L0",
+	"L0S",
+	"L123_SEND_EIDLE",
+	"L1_IDLE",
+	"L2_IDLE",
+	"L2_WAKE",
+	"DISABLED_ENTRY",
+	"DISABLED_IDLE",
+	"DISABLED",
+	"LPBK_ENTRY",
+	"LPBK_ACTIVE",
+	"LPBK_EXIT",
+	"LPBK_EXIT_TIMEOUT",
+	"HOT_RESET_ENTRY",
+	"HOT_RESET",
+	"RCVRY_EQ0",
+	"RCVRY_EQ1",
+	"RCVRY_EQ2",
+	"RCVRY_EQ3"
+};
+
 struct cxl_get_cxl_link_status_out {
 	float cxl_link_status;
 	uint32_t link_width;
@@ -10705,7 +10745,7 @@ CXL_EXPORT int cxl_memdev_get_cxl_link_status(struct cxl_memdev *memdev)
 	fprintf(stdout, "Link is in CXL%0.1f mode\n", get_cxl_link_status_out->cxl_link_status);
 	fprintf(stdout, "Negotiated link width: x%d\n", get_cxl_link_status_out->link_width);
 	fprintf(stdout, "Negotiated link speed: Gen%d\n", get_cxl_link_status_out->link_speed);
-	fprintf(stdout, "ltssm state 0x%x\n", get_cxl_link_status_out->ltssm_val);
+	fprintf(stdout, "ltssm state: %s, code 0x%x\n", ltssm_state_name[get_cxl_link_status_out->ltssm_val], get_cxl_link_status_out->ltssm_val);
 out:
 	cxl_cmd_unref(cmd);
 	return rc;

--- a/cxl/lib/libcxl.sym
+++ b/cxl/lib/libcxl.sym
@@ -177,4 +177,5 @@ global:
     cxl_memdev_pcie_eye_get_sw_ber;
     cxl_memdev_get_cxl_link_status;
     cxl_memdev_get_device_info;
+    cxl_memdev_read_ddr_temp;
 } LIBCXL_3;

--- a/cxl/libcxl.h
+++ b/cxl/libcxl.h
@@ -244,6 +244,7 @@ int cxl_memdev_pcie_eye_get_hw(struct cxl_memdev *memdev);
 int cxl_memdev_pcie_eye_get_sw_ber(struct cxl_memdev *memdev);
 int cxl_memdev_get_cxl_link_status(struct cxl_memdev *memdev);
 int cxl_memdev_get_device_info(struct cxl_memdev *memdev);
+int cxl_memdev_read_ddr_temp(struct cxl_memdev *memdev);
 
 #define cxl_memdev_foreach(ctx, memdev) \
         for (memdev = cxl_memdev_get_first(ctx); \

--- a/cxl/memdev.c
+++ b/cxl/memdev.c
@@ -1963,6 +1963,11 @@ static const struct option cmd_get_device_info_options[] = {
   OPT_END(),
 };
 
+static const struct option cmd_read_ddr_temp_options[] = {
+  BASE_OPTIONS(),
+  OPT_END(),
+};
+
 static int action_cmd_clear_event_records(struct cxl_memdev *memdev, struct action_context *actx)
 {
   u16 record_handle;
@@ -3625,6 +3630,18 @@ static int action_cmd_get_device_info(struct cxl_memdev *memdev,
 	return cxl_memdev_get_device_info(memdev);
 }
 
+static int action_cmd_read_ddr_temp(struct cxl_memdev *memdev,
+				      struct action_context *actx)
+{
+	if (cxl_memdev_is_active(memdev)) {
+		fprintf(stderr, "%s: memdev active, abort read_ddr_temp\n",
+			cxl_memdev_get_devname(memdev));
+		return -EBUSY;
+	}
+
+	return cxl_memdev_read_ddr_temp(memdev);
+}
+
 static int action_write(struct cxl_memdev *memdev, struct action_context *actx)
 {
   size_t size = param.len, read_len;
@@ -4735,6 +4752,14 @@ int cmd_get_device_info(int argc, const char **argv, struct cxl_ctx *ctx)
 {
   int rc = memdev_action(argc, argv, ctx, action_cmd_get_device_info, cmd_get_device_info_options,
       "cxl get_device_info <mem0> [<mem1>..<memN>] [<options>]");
+
+  return rc >= 0 ? 0 : EXIT_FAILURE;
+}
+
+int cmd_read_ddr_temp(int argc, const char **argv, struct cxl_ctx *ctx)
+{
+  int rc = memdev_action(argc, argv, ctx, action_cmd_read_ddr_temp, cmd_read_ddr_temp_options,
+      "cxl read_ddr_temp <mem0> [<mem1>..<memN>] [<options>]");
 
   return rc >= 0 ? 0 : EXIT_FAILURE;
 }


### PR DESCRIPTION
Summary:
Add vistara vendor command to read DDR temperature

Test log:
Number of DDR temperature sensors reported: 4
dimm_id : 0x0
spd_idx: 0x50
dimm temp: 40.000000
dimm_id : 0x1
spd_idx: 0x51
dimm temp: 39.000000
dimm_id : 0x2
spd_idx: 0x52
dimm temp: 39.750000
dimm_id : 0x3
spd_idx: 0x53
dimm temp: 39.000000