### PR TITLE
Add support for firmware update and fw info for boot2 and boot1 images

### DIFF
--- a/cxl/libcxl.h
+++ b/cxl/libcxl.h
@@ -3,6 +3,7 @@
 #ifndef _LIBCXL_H_
 #define _LIBCXL_H_
 
+#include <stdbool.h>
 #include <stdarg.h>
 #include <unistd.h>
 #include <sys/types.h>
@@ -57,7 +58,7 @@ int cxl_memdev_set_lsa(struct cxl_memdev *memdev, void *buf, size_t length,
 		size_t offset);
 int cxl_memdev_cmd_identify(struct cxl_memdev *memdev);
 int cxl_memdev_device_info_get(struct cxl_memdev *memdev);
-int cxl_memdev_get_fw_info(struct cxl_memdev *memdev);
+int cxl_memdev_get_fw_info(struct cxl_memdev *memdev, bool is_os_img);
 int cxl_memdev_transfer_fw(struct cxl_memdev *memdev, u8 action,
 	u8 slot, u32 offset, int size, unsigned char *data, u32 transfer_fw_opcode);
 int cxl_memdev_activate_fw(struct cxl_memdev *memdev, u8 action,


### PR DESCRIPTION
Summary:
Add support for firmware update in compatible with existing implementation for pioneer and new vendor commands for vistara to update OS(i.e. boot1 image). info.

Tests:
FW info:
	./cxl/cxl get-fw-info mem0
OS info:
	./cxl/cxl get-fw-info mem0 -z
FW update:
	./cxl/cxl update-fw mem0 -s <staged fw slot> -f <boot2 image file>
	e.g. ./cxl/cxl update-fw mem0 -s 1 -f vistara_fw-rootid0.bin

OS update:
	./cxl/cxl update-fw mem0 -s <staged os slot> -z -f <boot1 image file>
	e.g. ./cxl/cxl update-fw mem0 -s 1 -z -f os-rootid0.img