### PR TITLE
Add HPA to DPA mailbox command support

### DIFF
--- a/cxl/builtin.h
+++ b/cxl/builtin.h
@@ -123,4 +123,5 @@ int cmd_pcie_eye_get(int argc, const char **argv, struct cxl_ctx *ctx);
 int cmd_get_cxl_link_status(int argc, const char **argv, struct cxl_ctx *ctx);
 int cmd_get_device_info(int argc, const char **argv, struct cxl_ctx *ctx);
 int cmd_read_ddr_temp(int argc, const char **argv, struct cxl_ctx *ctx);
+int cmd_cxl_hpa_to_dpa(int argc, const char **argv, struct cxl_ctx *ctx);
 #endif /* _CXL_BUILTIN_H_ */

--- a/cxl/cxl.c
+++ b/cxl/cxl.c
@@ -179,6 +179,7 @@ static struct cmd_struct commands[] = {
 	{ "get-cxl-link-status", .c_fn = cmd_get_cxl_link_status },
 	{ "get-device-info", .c_fn = cmd_get_device_info },
 	{ "read-ddr-temp", .c_fn = cmd_read_ddr_temp },
+	{ "cxl-hpa-to-dpa", .c_fn = cmd_cxl_hpa_to_dpa },
 };
 
 int main(int argc, const char **argv)

--- a/cxl/lib/libcxl.c
+++ b/cxl/lib/libcxl.c
@@ -10883,3 +10883,65 @@ out:
 	cxl_cmd_unref(cmd);
 	return rc;
 }
+
+#define CXL_MEM_COMMAND_ID_CXL_HPA_TO_DPA CXL_MEM_COMMAND_ID_RAW
+#define CXL_MEM_COMMAND_ID_CXL_HPA_TO_DPA_OPCODE 0xFB14
+#define CXL_MEM_COMMAND_ID_CXL_HPA_TO_DPA_IN_PAYLOAD_SIZE sizeof(u64)
+
+CXL_EXPORT int cxl_memdev_cxl_hpa_to_dpa(struct cxl_memdev *memdev, u64 hpa_address)
+{
+	struct cxl_cmd *cmd;
+	struct cxl_command_info *cinfo;
+	struct cxl_mem_query_commands *query;
+	int rc = 0;
+	u64 *dpa_address_out;
+	u64 *hpa_address_in;
+
+	cmd = cxl_cmd_new_raw(memdev, CXL_MEM_COMMAND_ID_CXL_HPA_TO_DPA_OPCODE);
+	if (!cmd) {
+		fprintf(stderr, "%s: cxl_cmd_new_raw returned Null output\n",
+				cxl_memdev_get_devname(memdev));
+		return -ENOMEM;
+	}
+
+	query = cmd->query_cmd;
+	cinfo = &query->commands[cmd->query_idx];
+	/* used to force correct payload size */
+	cinfo->size_in = CXL_MEM_COMMAND_ID_CXL_HPA_TO_DPA_IN_PAYLOAD_SIZE;
+	if (cinfo->size_in > 0) {
+		cmd->input_payload = calloc(1, cinfo->size_in);
+		if (!cmd->input_payload)
+			return -ENOMEM;
+		cmd->send_cmd->in.payload = (u64)cmd->input_payload;
+		cmd->send_cmd->in.size = cinfo->size_in;
+	}
+
+	hpa_address_in = (void *)cmd->send_cmd->in.payload;
+	*hpa_address_in = hpa_address;
+
+	rc = cxl_cmd_submit(cmd);
+	if (rc < 0) {
+		fprintf(stderr, "%s: cmd submission failed: %d (%s)\n",
+				cxl_memdev_get_devname(memdev), rc, strerror(-rc));
+		goto out;
+	}
+
+	rc = cxl_cmd_get_mbox_status(cmd);
+	if (rc != 0) {
+		fprintf(stderr, "%s: Read failed, firmware status: %d\n",
+				cxl_memdev_get_devname(memdev), rc);
+		goto out;
+	}
+
+	if (cmd->send_cmd->id != CXL_MEM_COMMAND_ID_CXL_HPA_TO_DPA) {
+		fprintf(stderr, "%s: invalid command id 0x%x (expecting 0x%x)\n",
+				cxl_memdev_get_devname(memdev), cmd->send_cmd->id, CXL_MEM_COMMAND_ID_CXL_HPA_TO_DPA);
+		return -EINVAL;
+	}
+	dpa_address_out = (void*)cmd->send_cmd->out.payload;
+	fprintf(stdout, "dpa address:0x%lx\n", *dpa_address_out);
+
+out:
+	cxl_cmd_unref(cmd);
+	return rc;
+}

--- a/cxl/lib/libcxl.sym
+++ b/cxl/lib/libcxl.sym
@@ -178,4 +178,5 @@ global:
     cxl_memdev_get_cxl_link_status;
     cxl_memdev_get_device_info;
     cxl_memdev_read_ddr_temp;
+    cxl_memdev_cxl_hpa_to_dpa;
 } LIBCXL_3;

--- a/cxl/libcxl.h
+++ b/cxl/libcxl.h
@@ -245,6 +245,7 @@ int cxl_memdev_pcie_eye_get_sw_ber(struct cxl_memdev *memdev);
 int cxl_memdev_get_cxl_link_status(struct cxl_memdev *memdev);
 int cxl_memdev_get_device_info(struct cxl_memdev *memdev);
 int cxl_memdev_read_ddr_temp(struct cxl_memdev *memdev);
+int cxl_memdev_cxl_hpa_to_dpa(struct cxl_memdev *memdev, u64 hpa_address);
 
 #define cxl_memdev_foreach(ctx, memdev) \
         for (memdev = cxl_memdev_get_first(ctx); \


### PR DESCRIPTION
Summary: Add Host Physical address[HPA] to Device Physical address [DPA] conversion mailbox command implementation

Test Plan:
[root@suncl2h1 ndctl]# ./cxl/cxl cxl-hpa-to-dpa mem0 --hpa 0x1000000000 dpa address:0x1000000000

Reviewers:

Subscribers:

Tasks: T169153843
Tags: