### PR TITLE
Increase i2c read max number of bytes size for vendor command

### DIFF
--- a/cxl/lib/libcxl.c
+++ b/cxl/lib/libcxl.c
@@ -11701,7 +11701,7 @@ out:
 
 #define CXL_MEM_COMMAND_ID_I2C_READ CXL_MEM_COMMAND_ID_RAW
 #define CXL_MEM_COMMAND_ID_I2C_READ_OPCODE 0xFB10
-#define I2C_MAX_SIZE_NUM_BYTES 64
+#define I2C_MAX_SIZE_NUM_BYTES 128
 
 struct cxl_i2c_read_in {
 	u16 slave_addr;


### PR DESCRIPTION
Summary:
Increase i2c read max number of bytes size for vendor command

Test Plan:
 usage: cxl i2c-read <mem0> [<mem1>..<memN>] [<options>]
    -v, --verbose         turn on debug
    -s, --slave_addr <n>  Slave addr
    -r, --reg_addr <n>    Reg addr
    -n, --num_bytes <n>   Number of bytes

i2c read output:0x23	0x11	0xc	0x1	0xffffff85	0x29	0x0	0x8	0x0	0x60	0x0	0x3	0x100xb	0xffffff80	0x0	0x0	0x0	0x7	0xd	0xfffffff8	0xf	0x0	0x0	0x6e	0x6e	0x6e0x11	0x0	0x6e	0xfffffff0	0xa	0x20	0x8	0x0	0x5	0x0	0x68	0x1b	0x28	0x28	0x00x78	0x0	0x14	0x3c	0x0	0x0	0x0	0x0	0x0	0x0	0x0	0x0	0x0	0x0	0x0	0x00x0	0x0	0x16	0x16	0x16	0x16	0x16	0x16	0x16	0x16	0x16	0x16	0x16	0x16	0x16	0x160x16	0x16	0x16	0x16	0x0	0x0	0x0	0x0	0x0	0x0	0x0	0x0	0x0	0x0	0x0	0x00x0	0x0	0x0	0x0	0x0	0x0	0x0	0x0	0x0	0x0	0x0	0x0	0x0	0x0	0x0	0x00x0	0x0	0x0	0x0	0x0	0x0	0x0	0x0	0x0	0x0	0x0	0x0	0xffffff9c	0xffffffb5	0x0	0x0	0x0	0x0	0xffffffe7	0xffffffd6	0x6a	0xffffffc9

Reviewers:

Subscribers:

Tasks: T163764744

Tags: