### PR TITLE
Fix 4byte align on vendor command ddr temperature

### DIFF
--- a/cxl/lib/libcxl.c
+++ b/cxl/lib/libcxl.c
@@ -11209,6 +11209,7 @@ struct ddr_dimm_temp_info {
     uint8_t ddr_temp_valid;
     uint8_t dimm_id;
     uint8_t spd_idx;
+    uint8_t rsvd;
     float dimm_temp;
 };
 


### PR DESCRIPTION
Summary:
Fix 4byte align on vendor command ddr temperature
Align the ddr temperature output payload size to 4btes

Test Plan:
Fix 4byte align on vendor command ddr temperature

Reviewers:

Subscribers:

Tasks: T173931233,D52477654

Tags: