### PR TITLE
Add new vendor command to get ddr latency

### DIFF
--- a/cxl/builtin.h
+++ b/cxl/builtin.h
@@ -131,6 +131,7 @@ int cmd_read_ddr_temp(int argc, const char **argv, struct cxl_ctx *ctx);
 int cmd_cxl_hpa_to_dpa(int argc, const char **argv, struct cxl_ctx *ctx);
 int cmd_get_cxl_membridge_errors(int argc, const char **argv, struct cxl_ctx *ctx);
 int cmd_get_ddr_bw(int argc, const char **argv, struct cxl_ctx *ctx);
+int cmd_get_ddr_latency(int argc, const char **argv, struct cxl_ctx *ctx);
 int cmd_i2c_read(int argc, const char **argv, struct cxl_ctx *ctx);
 int cmd_i2c_write(int argc, const char **argv, struct cxl_ctx *ctx);
 int cmd_get_ddr_ecc_err_info(int argc, const char **argv, struct cxl_ctx *ctx);

--- a/cxl/cxl.c
+++ b/cxl/cxl.c
@@ -187,6 +187,7 @@ static struct cmd_struct commands[] = {
 	{ "cxl-hpa-to-dpa", .c_fn = cmd_cxl_hpa_to_dpa },
 	{ "get-cxl-membridge-errors", .c_fn = cmd_get_cxl_membridge_errors },
 	{ "get-ddr-bw", .c_fn = cmd_get_ddr_bw },
+	{ "get-ddr-latency", .c_fn = cmd_get_ddr_latency },
 	{ "i2c-read", .c_fn = cmd_i2c_read },
 	{ "i2c-write", .c_fn = cmd_i2c_write },
 	{ "get-ddr-ecc-err-info", .c_fn = cmd_get_ddr_ecc_err_info },

--- a/cxl/lib/libcxl.sym
+++ b/cxl/lib/libcxl.sym
@@ -186,6 +186,7 @@ global:
     cxl_memdev_cxl_hpa_to_dpa;
     cxl_memdev_get_cxl_membridge_errors;
     cxl_memdev_get_ddr_bw;
+    cxl_memdev_get_ddr_latency;
     cxl_memdev_i2c_read;
     cxl_memdev_i2c_write;
     cxl_memdev_get_ddr_ecc_err_info;

--- a/cxl/libcxl.h
+++ b/cxl/libcxl.h
@@ -254,6 +254,7 @@ int cxl_memdev_read_ddr_temp(struct cxl_memdev *memdev);
 int cxl_memdev_cxl_hpa_to_dpa(struct cxl_memdev *memdev, u64 hpa_address);
 int cxl_memdev_get_cxl_membridge_errors(struct cxl_memdev *memdev);
 int cxl_memdev_get_ddr_bw(struct cxl_memdev *memdev, u32 timeout, u32 iterations);
+int cxl_memdev_get_ddr_latency(struct cxl_memdev *memdev, u32 measure_time);
 int cxl_memdev_i2c_read(struct cxl_memdev *memdev, u16 slave_addr, u8 reg_addr, u8 num_bytes);
 int cxl_memdev_i2c_write(struct cxl_memdev *memdev, u16 slave_addr, u8 reg_addr, u8 data);
 int cxl_memdev_get_ddr_ecc_err_info(struct cxl_memdev *memdev);

--- a/cxl/memdev.c
+++ b/cxl/memdev.c
@@ -2055,6 +2055,20 @@ static const struct option cmd_get_ddr_bw_options[] = {
   OPT_END(),
 };
 
+static struct _get_ddr_latency_params {
+	u32 measure_time;
+	bool verbose;
+} get_ddr_latency_params;
+
+#define GET_DDR_LATENCY_OPTIONS() \
+OPT_UINTEGER('t', "measure time", &get_ddr_latency_params.measure_time, "Measure Time in msec")
+
+static const struct option cmd_get_ddr_latency_options[] = {
+  BASE_OPTIONS(),
+  GET_DDR_LATENCY_OPTIONS(),
+  OPT_END(),
+};
+
 static struct _i2c_read_params {
 	u32 slave_addr;
 	u32 reg_addr;
@@ -3896,6 +3910,18 @@ static int action_cmd_get_ddr_bw(struct cxl_memdev *memdev,
 	return cxl_memdev_get_ddr_bw(memdev, get_ddr_bw_params.timeout, get_ddr_bw_params.iterations);
 }
 
+static int action_cmd_get_ddr_latency(struct cxl_memdev *memdev,
+				      struct action_context *actx)
+{
+	if (cxl_memdev_is_active(memdev)) {
+		fprintf(stderr, "%s: memdev active, abort get_ddr_latency\n",
+			cxl_memdev_get_devname(memdev));
+		return -EBUSY;
+	}
+
+	return cxl_memdev_get_ddr_latency(memdev, get_ddr_latency_params.measure_time);
+}
+
 static int action_cmd_i2c_read(struct cxl_memdev *memdev,
 				      struct action_context *actx)
 {
@@ -5114,6 +5140,14 @@ int cmd_get_ddr_bw(int argc, const char **argv, struct cxl_ctx *ctx)
 {
   int rc = memdev_action(argc, argv, ctx, action_cmd_get_ddr_bw, cmd_get_ddr_bw_options,
       "cxl get-ddr-bw <mem0> [<mem1>..<memN>] [<options>]");
+
+  return rc >= 0 ? 0 : EXIT_FAILURE;
+}
+
+int cmd_get_ddr_latency(int argc, const char **argv, struct cxl_ctx *ctx)
+{
+  int rc = memdev_action(argc, argv, ctx, action_cmd_get_ddr_latency, cmd_get_ddr_latency_options,
+      "cxl get-ddr-latency <mem0> [<mem1>..<memN>] [<options>]");
 
   return rc >= 0 ? 0 : EXIT_FAILURE;
 }


### PR DESCRIPTION
Summary:
Add new vendor command to get ddr latency

Test Plan:
usage: cxl get-ddr-latency <mem0> [<mem1>..<memN>] [<options>]
-v, --verbose         turn on debug
-t, --measure time <n>  Measure Time

DDR0 Latency:
readLat: 12519463274, rdSampleCnt: 77043143, writeLat: 69816476, wrSampleCnt: 34908238 Average Latency:
Avg Read Latency  : 162.499390 ns
Avg Write Latency : 2.000000 ns

DDR1 Latency:
readLat: 12496321792, rdSampleCnt: 77015865, writeLat: 69816112, wrSampleCnt: 34908056 Average Latency:
Avg Read Latency  : 162.256470 ns
Avg Write Latency : 2.000000 ns

Reviewers:

Subscribers:

Tasks: T174115520, D52591190

Tags: