### PR TITLE
Add new vendor command to start ddr ecc scrub

### DIFF
--- a/cxl/builtin.h
+++ b/cxl/builtin.h
@@ -135,4 +135,6 @@ int cmd_get_ddr_latency(int argc, const char **argv, struct cxl_ctx *ctx);
 int cmd_i2c_read(int argc, const char **argv, struct cxl_ctx *ctx);
 int cmd_i2c_write(int argc, const char **argv, struct cxl_ctx *ctx);
 int cmd_get_ddr_ecc_err_info(int argc, const char **argv, struct cxl_ctx *ctx);
+int cmd_start_ddr_ecc_scrub(int argc, const char **argv, struct cxl_ctx *ctx);
+int cmd_ddr_ecc_scrub_status(int argc, const char **argv, struct cxl_ctx *ctx);
 #endif /* _CXL_BUILTIN_H_ */

--- a/cxl/cxl.c
+++ b/cxl/cxl.c
@@ -191,6 +191,8 @@ static struct cmd_struct commands[] = {
 	{ "i2c-read", .c_fn = cmd_i2c_read },
 	{ "i2c-write", .c_fn = cmd_i2c_write },
 	{ "get-ddr-ecc-err-info", .c_fn = cmd_get_ddr_ecc_err_info },
+	{ "start-ddr-ecc-scrub", .c_fn = cmd_start_ddr_ecc_scrub },
+	{ "ddr-ecc-scrub-status", .c_fn = cmd_ddr_ecc_scrub_status },
 };
 
 int main(int argc, const char **argv)

--- a/cxl/lib/libcxl.c
+++ b/cxl/lib/libcxl.c
@@ -12211,3 +12211,128 @@ out:
         cxl_cmd_unref(cmd);
         return rc;
 }
+
+#define CXL_MEM_COMMAND_ID_START_DDR_ECC_SCRUB CXL_MEM_COMMAND_ID_RAW
+#define CXL_MEM_COMMAND_ID_START_DDR_ECC_SCRUB_OPCODE 0xFB15
+
+CXL_EXPORT int cxl_memdev_start_ddr_ecc_scrub(struct cxl_memdev *memdev)
+{
+	struct cxl_cmd *cmd;
+	struct cxl_mem_query_commands *query;
+	struct cxl_command_info *cinfo;
+	int rc = 0;
+
+	cmd = cxl_cmd_new_raw(memdev, CXL_MEM_COMMAND_ID_START_DDR_ECC_SCRUB_OPCODE);
+	if (!cmd) {
+		fprintf(stderr, "%s: cxl_cmd_new_raw returned Null output\n",
+				cxl_memdev_get_devname(memdev));
+		return -ENOMEM;
+	}
+
+	query = cmd->query_cmd;
+	cinfo = &query->commands[cmd->query_idx];
+
+	/* used to force correct payload size */
+	cinfo->size_in = CXL_MEM_COMMAND_ID_LOG_INFO_PAYLOAD_IN_SIZE;
+	if (cinfo->size_in > 0) {
+		cmd->input_payload = calloc(1, cinfo->size_in);
+		if (!cmd->input_payload)
+			return -ENOMEM;
+		cmd->send_cmd->in.payload = (u64)cmd->input_payload;
+		cmd->send_cmd->in.size = cinfo->size_in;
+	}
+
+	rc = cxl_cmd_submit(cmd);
+	if (rc < 0) {
+		fprintf(stderr, "%s: cmd submission failed: %d (%s)\n",
+				cxl_memdev_get_devname(memdev), rc, strerror(-rc));
+		goto out;
+	}
+
+	rc = cxl_cmd_get_mbox_status(cmd);
+	if (rc != 0) {
+		fprintf(stderr, "%s: Read failed, firmware status: %d\n",
+				cxl_memdev_get_devname(memdev), rc);
+		goto out;
+	}
+
+	if (cmd->send_cmd->id != CXL_MEM_COMMAND_ID_START_DDR_ECC_SCRUB) {
+		fprintf(stderr, "%s: invalid command id 0x%x (expecting 0x%x)\n",
+				cxl_memdev_get_devname(memdev), cmd->send_cmd->id, CXL_MEM_COMMAND_ID_START_DDR_ECC_SCRUB);
+		return -EINVAL;
+	}
+
+out:
+	cxl_cmd_unref(cmd);
+	return rc;
+}
+
+#define CXL_MEM_COMMAND_ID_DDR_ECC_SCRUB_STATUS CXL_MEM_COMMAND_ID_RAW
+#define CXL_MEM_COMMAND_ID_DDR_ECC_SCRUB_STATUS_OPCODE 0xFB16
+
+
+struct cxl_ddr_ecc_scrub_status_out {
+  int ecc_scrub_status[DDR_MAX_SUBSYS];
+} __attribute__((packed));
+
+
+CXL_EXPORT int cxl_memdev_ddr_ecc_scrub_status(struct cxl_memdev *memdev)
+{
+	struct cxl_cmd *cmd;
+	struct cxl_mem_query_commands *query;
+	struct cxl_command_info *cinfo;
+	struct cxl_ddr_ecc_scrub_status_out *ddr_ecc_scrub_status_out;
+	int rc = 0;
+	int subsys;
+
+	cmd = cxl_cmd_new_raw(memdev, CXL_MEM_COMMAND_ID_DDR_ECC_SCRUB_STATUS_OPCODE);
+	if (!cmd) {
+		fprintf(stderr, "%s: cxl_cmd_new_raw returned Null output\n",
+				cxl_memdev_get_devname(memdev));
+		return -ENOMEM;
+	}
+
+	query = cmd->query_cmd;
+	cinfo = &query->commands[cmd->query_idx];
+
+	/* used to force correct payload size */
+	cinfo->size_in = CXL_MEM_COMMAND_ID_LOG_INFO_PAYLOAD_IN_SIZE;
+	if (cinfo->size_in > 0) {
+		 cmd->input_payload = calloc(1, cinfo->size_in);
+		if (!cmd->input_payload)
+			return -ENOMEM;
+		cmd->send_cmd->in.payload = (u64)cmd->input_payload;
+		cmd->send_cmd->in.size = cinfo->size_in;
+	}
+
+	rc = cxl_cmd_submit(cmd);
+	if (rc < 0) {
+		fprintf(stderr, "%s: cmd submission failed: %d (%s)\n",
+				cxl_memdev_get_devname(memdev), rc, strerror(-rc));
+		 goto out;
+	}
+
+	rc = cxl_cmd_get_mbox_status(cmd);
+	if (rc != 0) {
+		fprintf(stderr, "%s: firmware status: %d\n",
+				cxl_memdev_get_devname(memdev), rc);
+		goto out;
+	}
+
+	if (cmd->send_cmd->id != CXL_MEM_COMMAND_ID_DDR_ECC_SCRUB_STATUS) {
+		fprintf(stderr, "%s: invalid command id 0x%x (expecting 0x%x)\n",
+				cxl_memdev_get_devname(memdev), cmd->send_cmd->id,
+				CXL_MEM_COMMAND_ID_DDR_ECC_SCRUB_STATUS);
+		return -EINVAL;
+	}
+	ddr_ecc_scrub_status_out = (void *)cmd->send_cmd->out.payload;
+	for(subsys = DDR_CTRL0; subsys < DDR_MAX_SUBSYS; subsys++)
+	{
+		fprintf(stdout, "DDR-%d %s\n", subsys, ddr_ecc_scrub_status_out->ecc_scrub_status[subsys] ?
+				"ECC SCRUB IS IN PROGRESS" : "DDR SCRUB IS NOT RUNNING/FINISHED");
+	}
+
+out:
+        cxl_cmd_unref(cmd);
+        return rc;
+}

--- a/cxl/lib/libcxl.sym
+++ b/cxl/lib/libcxl.sym
@@ -190,4 +190,6 @@ global:
     cxl_memdev_i2c_read;
     cxl_memdev_i2c_write;
     cxl_memdev_get_ddr_ecc_err_info;
+    cxl_memdev_start_ddr_ecc_scrub;
+    cxl_memdev_ddr_ecc_scrub_status;
 } LIBCXL_3;

--- a/cxl/libcxl.h
+++ b/cxl/libcxl.h
@@ -258,6 +258,8 @@ int cxl_memdev_get_ddr_latency(struct cxl_memdev *memdev, u32 measure_time);
 int cxl_memdev_i2c_read(struct cxl_memdev *memdev, u16 slave_addr, u8 reg_addr, u8 num_bytes);
 int cxl_memdev_i2c_write(struct cxl_memdev *memdev, u16 slave_addr, u8 reg_addr, u8 data);
 int cxl_memdev_get_ddr_ecc_err_info(struct cxl_memdev *memdev);
+int cxl_memdev_start_ddr_ecc_scrub(struct cxl_memdev *memdev);
+int cxl_memdev_ddr_ecc_scrub_status(struct cxl_memdev *memdev);
 
 #define cxl_memdev_foreach(ctx, memdev) \
         for (memdev = cxl_memdev_get_first(ctx); \

--- a/cxl/memdev.c
+++ b/cxl/memdev.c
@@ -2110,6 +2110,16 @@ static const struct option cmd_get_ddr_ecc_err_info_options[] = {
   OPT_END(),
 };
 
+static const struct option cmd_start_ddr_ecc_scrub_options[] = {
+  BASE_OPTIONS(),
+  OPT_END(),
+};
+
+static const struct option cmd_ddr_ecc_scrub_status_options[] = {
+  BASE_OPTIONS(),
+  OPT_END(),
+};
+
 static int action_cmd_clear_event_records(struct cxl_memdev *memdev, struct action_context *actx)
 {
   u16 record_handle;
@@ -3958,6 +3968,30 @@ static int action_cmd_get_ddr_ecc_err_info(struct cxl_memdev *memdev,
 	return cxl_memdev_get_ddr_ecc_err_info(memdev);
 }
 
+static int action_cmd_start_ddr_ecc_scrub(struct cxl_memdev *memdev,
+				      struct action_context *actx)
+{
+	if (cxl_memdev_is_active(memdev)) {
+		fprintf(stderr, "%s: memdev active, abort start-ddr-ecc-scrub\n",
+			cxl_memdev_get_devname(memdev));
+		return -EBUSY;
+	}
+
+	return cxl_memdev_start_ddr_ecc_scrub(memdev);
+}
+
+static int action_cmd_ddr_ecc_scrub_status(struct cxl_memdev *memdev,
+				      struct action_context *actx)
+{
+	if (cxl_memdev_is_active(memdev)) {
+		fprintf(stderr, "%s: memdev active, abort ddr-ecc-scrub-status\n",
+			cxl_memdev_get_devname(memdev));
+		return -EBUSY;
+	}
+
+	return cxl_memdev_ddr_ecc_scrub_status(memdev);
+}
+
 static int action_write(struct cxl_memdev *memdev, struct action_context *actx)
 {
   size_t size = param.len, read_len;
@@ -5172,6 +5206,22 @@ int cmd_get_ddr_ecc_err_info(int argc, const char **argv, struct cxl_ctx *ctx)
 {
   int rc = memdev_action(argc, argv, ctx, action_cmd_get_ddr_ecc_err_info, cmd_get_ddr_ecc_err_info_options,
       "cxl get-ddr-ecc-err-info <mem0> [<mem1>..<memN>] [<options>]");
+
+  return rc >= 0 ? 0 : EXIT_FAILURE;
+}
+
+int cmd_start_ddr_ecc_scrub(int argc, const char **argv, struct cxl_ctx *ctx)
+{
+  int rc = memdev_action(argc, argv, ctx, action_cmd_start_ddr_ecc_scrub, cmd_start_ddr_ecc_scrub_options,
+      "cxl start-ddr-ecc-scrub <mem0> [<mem1>..<memN>] [<options>]");
+
+  return rc >= 0 ? 0 : EXIT_FAILURE;
+}
+
+int cmd_ddr_ecc_scrub_status(int argc, const char **argv, struct cxl_ctx *ctx)
+{
+  int rc = memdev_action(argc, argv, ctx, action_cmd_ddr_ecc_scrub_status, cmd_ddr_ecc_scrub_status_options,
+      "cxl ddr-ecc-scrub-status <mem0> [<mem1>..<memN>] [<options>]");
 
   return rc >= 0 ? 0 : EXIT_FAILURE;
 }


### PR DESCRIPTION
Summary: Add new vendor command to start ddr ecc scrub operation

Test Plan:
usage: cxl start-ddr-ecc-scrub <mem0> [<mem1>..<memN>] [<options>]
       -v, --verbose         turn on debug

sample : ./cxl start-ddr-ecc-scrub mem0

Ouptut: # ./cxl start-ddr-ecc-scrub mem0

usage: cxl ddr-ecc-scrub-status <mem0> [<mem1>..<memN>] [<options>]
       -v, --verbose         turn on debug

sample : ./cxl ddr-ecc-scrub-status mem0

Ouptut:
./cxl ddr-ecc-scrub-status mem0
DDR-0 ECC SCRUB IS IN PROGRESS
DDR-1 ECC SCRUB IS IN PROGRESS
./cxl ddr-ecc-scrub-status mem0
DDR-0 DDR SCRUB IS NOT RUNNING/FINISHED
DDR-1 DDR SCRUB IS NOT RUNNING/FINISHED

Reviewers:

Subscribers:

Tasks: T125904383

Tags: