### PR TITLE
Add new vendor command to ddr init status

### DIFF
--- a/cxl/builtin.h
+++ b/cxl/builtin.h
@@ -137,4 +137,5 @@ int cmd_i2c_write(int argc, const char **argv, struct cxl_ctx *ctx);
 int cmd_get_ddr_ecc_err_info(int argc, const char **argv, struct cxl_ctx *ctx);
 int cmd_start_ddr_ecc_scrub(int argc, const char **argv, struct cxl_ctx *ctx);
 int cmd_ddr_ecc_scrub_status(int argc, const char **argv, struct cxl_ctx *ctx);
+int cmd_ddr_init_status(int argc, const char **argv, struct cxl_ctx *ctx);
 #endif /* _CXL_BUILTIN_H_ */

--- a/cxl/cxl.c
+++ b/cxl/cxl.c
@@ -193,6 +193,7 @@ static struct cmd_struct commands[] = {
 	{ "get-ddr-ecc-err-info", .c_fn = cmd_get_ddr_ecc_err_info },
 	{ "start-ddr-ecc-scrub", .c_fn = cmd_start_ddr_ecc_scrub },
 	{ "ddr-ecc-scrub-status", .c_fn = cmd_ddr_ecc_scrub_status },
+	{ "ddr-init-status", .c_fn = cmd_ddr_init_status },
 };
 
 int main(int argc, const char **argv)

--- a/cxl/lib/libcxl.sym
+++ b/cxl/lib/libcxl.sym
@@ -192,4 +192,5 @@ global:
     cxl_memdev_get_ddr_ecc_err_info;
     cxl_memdev_start_ddr_ecc_scrub;
     cxl_memdev_ddr_ecc_scrub_status;
+    cxl_memdev_ddr_init_status;
 } LIBCXL_3;

--- a/cxl/libcxl.h
+++ b/cxl/libcxl.h
@@ -260,6 +260,7 @@ int cxl_memdev_i2c_write(struct cxl_memdev *memdev, u16 slave_addr, u8 reg_addr,
 int cxl_memdev_get_ddr_ecc_err_info(struct cxl_memdev *memdev);
 int cxl_memdev_start_ddr_ecc_scrub(struct cxl_memdev *memdev);
 int cxl_memdev_ddr_ecc_scrub_status(struct cxl_memdev *memdev);
+int cxl_memdev_ddr_init_status(struct cxl_memdev *memdev);
 
 #define cxl_memdev_foreach(ctx, memdev) \
         for (memdev = cxl_memdev_get_first(ctx); \

--- a/cxl/memdev.c
+++ b/cxl/memdev.c
@@ -2120,6 +2120,11 @@ static const struct option cmd_ddr_ecc_scrub_status_options[] = {
   OPT_END(),
 };
 
+static const struct option cmd_ddr_init_status_options[] = {
+  BASE_OPTIONS(),
+  OPT_END(),
+};
+
 static int action_cmd_clear_event_records(struct cxl_memdev *memdev, struct action_context *actx)
 {
   u16 record_handle;
@@ -3992,6 +3997,18 @@ static int action_cmd_ddr_ecc_scrub_status(struct cxl_memdev *memdev,
 	return cxl_memdev_ddr_ecc_scrub_status(memdev);
 }
 
+static int action_cmd_ddr_init_status(struct cxl_memdev *memdev,
+				      struct action_context *actx)
+{
+	if (cxl_memdev_is_active(memdev)) {
+		fprintf(stderr, "%s: memdev active, abort ddr-init-status\n",
+			cxl_memdev_get_devname(memdev));
+		return -EBUSY;
+	}
+
+	return cxl_memdev_ddr_init_status(memdev);
+}
+
 static int action_write(struct cxl_memdev *memdev, struct action_context *actx)
 {
   size_t size = param.len, read_len;
@@ -5222,6 +5239,14 @@ int cmd_ddr_ecc_scrub_status(int argc, const char **argv, struct cxl_ctx *ctx)
 {
   int rc = memdev_action(argc, argv, ctx, action_cmd_ddr_ecc_scrub_status, cmd_ddr_ecc_scrub_status_options,
       "cxl ddr-ecc-scrub-status <mem0> [<mem1>..<memN>] [<options>]");
+
+  return rc >= 0 ? 0 : EXIT_FAILURE;
+}
+
+int cmd_ddr_init_status(int argc, const char **argv, struct cxl_ctx *ctx)
+{
+  int rc = memdev_action(argc, argv, ctx, action_cmd_ddr_init_status, cmd_ddr_init_status_options,
+      "cxl ddr-init-status <mem0> [<mem1>..<memN>] [<options>]");
 
   return rc >= 0 ? 0 : EXIT_FAILURE;
 }


### PR DESCRIPTION
Summary: Add new vendor command to get ddr init status

Test Plan:
usage: cxl ddr-init-status <mem0> [<mem1>..<memN>] [<options>]
    -v, --verbose         turn on debug

sample : ./cxl ddr-init-status mem0
DDR INIT PASSED

Reviewers:

Subscribers:

Tasks: T162539651

Tags: