### PR TITLE
vistara: vendor command for reading membridge statistics/counters

### DIFF
--- a/cxl/builtin.h
+++ b/cxl/builtin.h
@@ -137,4 +137,5 @@ int cmd_i2c_write(int argc, const char **argv, struct cxl_ctx *ctx);
 int cmd_get_ddr_ecc_err_info(int argc, const char **argv, struct cxl_ctx *ctx);
 int cmd_start_ddr_ecc_scrub(int argc, const char **argv, struct cxl_ctx *ctx);
 int cmd_ddr_ecc_scrub_status(int argc, const char **argv, struct cxl_ctx *ctx);
+int cmd_get_cxl_membridge_stats(int argc, const char **argv, struct cxl_ctx *ctx);
 #endif /* _CXL_BUILTIN_H_ */

--- a/cxl/cxl.c
+++ b/cxl/cxl.c
@@ -193,7 +193,7 @@ static struct cmd_struct commands[] = {
 	{ "get-ddr-ecc-err-info", .c_fn = cmd_get_ddr_ecc_err_info },
 	{ "start-ddr-ecc-scrub", .c_fn = cmd_start_ddr_ecc_scrub },
 	{ "ddr-ecc-scrub-status", .c_fn = cmd_ddr_ecc_scrub_status },
-  { "ddr-init-status", .c_fn = cmd_ddr_init_status },
+	{ "ddr-init-status", .c_fn = cmd_ddr_init_status },
 	{ "get-cxl-membridge-stats", .c_fn = cmd_get_cxl_membridge_stats },
 };
 

--- a/cxl/cxl.c
+++ b/cxl/cxl.c
@@ -193,6 +193,7 @@ static struct cmd_struct commands[] = {
 	{ "get-ddr-ecc-err-info", .c_fn = cmd_get_ddr_ecc_err_info },
 	{ "start-ddr-ecc-scrub", .c_fn = cmd_start_ddr_ecc_scrub },
 	{ "ddr-ecc-scrub-status", .c_fn = cmd_ddr_ecc_scrub_status },
+	{ "get-cxl-membridge-stats", .c_fn = cmd_get_cxl_membridge_stats },
 };
 
 int main(int argc, const char **argv)

--- a/cxl/lib/libcxl.sym
+++ b/cxl/lib/libcxl.sym
@@ -192,4 +192,5 @@ global:
     cxl_memdev_get_ddr_ecc_err_info;
     cxl_memdev_start_ddr_ecc_scrub;
     cxl_memdev_ddr_ecc_scrub_status;
+    cxl_memdev_get_cxl_membridge_stats;
 } LIBCXL_3;

--- a/cxl/libcxl.h
+++ b/cxl/libcxl.h
@@ -260,6 +260,7 @@ int cxl_memdev_i2c_write(struct cxl_memdev *memdev, u16 slave_addr, u8 reg_addr,
 int cxl_memdev_get_ddr_ecc_err_info(struct cxl_memdev *memdev);
 int cxl_memdev_start_ddr_ecc_scrub(struct cxl_memdev *memdev);
 int cxl_memdev_ddr_ecc_scrub_status(struct cxl_memdev *memdev);
+int cxl_memdev_get_cxl_membridge_stats(struct cxl_memdev *memdev);
 
 #define cxl_memdev_foreach(ctx, memdev) \
         for (memdev = cxl_memdev_get_first(ctx); \

--- a/cxl/memdev.c
+++ b/cxl/memdev.c
@@ -5269,6 +5269,5 @@ int cmd_get_cxl_membridge_stats(int argc, const char **argv, struct cxl_ctx *ctx
 {
   int rc = memdev_action(argc, argv, ctx, action_cmd_get_cxl_membridge_stats, cmd_get_cxl_membridge_stats_options,
       "cxl get_cxl_membridge_errors");
-
   return rc >= 0 ? 0 : EXIT_FAILURE;
 }

--- a/cxl/memdev.c
+++ b/cxl/memdev.c
@@ -2120,6 +2120,11 @@ static const struct option cmd_ddr_ecc_scrub_status_options[] = {
   OPT_END(),
 };
 
+static const struct option cmd_get_cxl_membridge_stats_options[] = {
+  BASE_OPTIONS(),
+  OPT_END(),
+};
+
 static int action_cmd_clear_event_records(struct cxl_memdev *memdev, struct action_context *actx)
 {
   u16 record_handle;
@@ -3992,6 +3997,18 @@ static int action_cmd_ddr_ecc_scrub_status(struct cxl_memdev *memdev,
 	return cxl_memdev_ddr_ecc_scrub_status(memdev);
 }
 
+static int action_cmd_get_cxl_membridge_stats(struct cxl_memdev *memdev,
+				      struct action_context *actx)
+{
+	if (cxl_memdev_is_active(memdev)) {
+		fprintf(stderr, "%s: memdev active, abort cxl membridge stats\n",
+			cxl_memdev_get_devname(memdev));
+		return -EBUSY;
+	}
+
+	return cxl_memdev_get_cxl_membridge_stats(memdev);
+}
+
 static int action_write(struct cxl_memdev *memdev, struct action_context *actx)
 {
   size_t size = param.len, read_len;
@@ -5222,6 +5239,14 @@ int cmd_ddr_ecc_scrub_status(int argc, const char **argv, struct cxl_ctx *ctx)
 {
   int rc = memdev_action(argc, argv, ctx, action_cmd_ddr_ecc_scrub_status, cmd_ddr_ecc_scrub_status_options,
       "cxl ddr-ecc-scrub-status <mem0> [<mem1>..<memN>] [<options>]");
+
+  return rc >= 0 ? 0 : EXIT_FAILURE;
+}
+
+int cmd_get_cxl_membridge_stats(int argc, const char **argv, struct cxl_ctx *ctx)
+{
+  int rc = memdev_action(argc, argv, ctx, action_cmd_get_cxl_membridge_stats, cmd_get_cxl_membridge_stats_options,
+      "cxl get_cxl_membridge_errors");
 
   return rc >= 0 ? 0 : EXIT_FAILURE;
 }

--- a/cxl/memdev.c
+++ b/cxl/memdev.c
@@ -5262,7 +5262,7 @@ int cmd_ddr_init_status(int argc, const char **argv, struct cxl_ctx *ctx)
 {
   int rc = memdev_action(argc, argv, ctx, action_cmd_ddr_init_status, cmd_ddr_init_status_options,
       "cxl ddr-init-status <mem0> [<mem1>..<memN>] [<options>]");
-      return rc >= 0 ? 0 : EXIT_FAILURE;
+  return rc >= 0 ? 0 : EXIT_FAILURE;
 }
 
 int cmd_get_cxl_membridge_stats(int argc, const char **argv, struct cxl_ctx *ctx)


### PR DESCRIPTION
   Summary: Add new vendor command to read memory bridge statistics & status

    Test Plan:
    usage: cxl get-cxl-membridge-stats <mem0> [<mem1>..<memN>] [<options>]
           -v, --verbose         turn on debug

    sample : ./cxl get-cxl-membridge-stats mem0

    Ouptut:
	m2s_req_count:              93578251
	m2s_rwd_count:              87955769
	s2m_drs_count:              93578251
	s2m_ndr_count:              87955769
	rwd_first_poison_hpa:       0x0
	rwd_latest_poison_hpa:      0x0
	req_first_hpa_log:          0x0
	rwd_first_hpa_log:          0x0
	m2s_req_corr_err_count:     0
	m2s_rwd_corr_err_count:     0
	fifo_full_status:           0x0
	fifo_empty_status:          0xffff
	m2s_rwd_credit_count:       8
	m2s_req_credit_count:       8
	s2m_ndr_credit_count:       8
	s2m_drc_credit_count:       8
	rx_status_rx_deinit:        4
	rx_status_m2s_req:          0x2
	rx_status_m2s_rwd:          0x2
	rx_status_ddr0_ar_req:      0x1
	rx_status_ddr0_aw_req:      0x1
	rx_status_ddr0_w_req:       0x1
	rx_status_ddr1_ar_req:      0x1
	rx_status_ddr1_aw_req:      0x1
	rx_status_ddr1_w_req:       0x1
	tx_status_tx_deinit:        0x4
	tx_status_s2m_ndr:          0x2
	tx_status_s2m_drc:          0x2
	qos_tel_dev_load_read:      0
	qos_tel_dev_load_type2_read:0
	qos_tel_dev_load_write:     0

    Reviewers:

    Subscribers:

    Tasks: T140075923

    Tags: