### PR TITLE
Summary: Add new vendor command to trigger coredump in device

### DIFF
--- a/cxl/builtin.h
+++ b/cxl/builtin.h
@@ -139,4 +139,5 @@ int cmd_start_ddr_ecc_scrub(int argc, const char **argv, struct cxl_ctx *ctx);
 int cmd_ddr_ecc_scrub_status(int argc, const char **argv, struct cxl_ctx *ctx);
 int cmd_ddr_init_status(int argc, const char **argv, struct cxl_ctx *ctx);
 int cmd_get_cxl_membridge_stats(int argc, const char **argv, struct cxl_ctx *ctx);
+int cmd_trigger_coredump(int argc, const char **argv, struct cxl_ctx *ctx);
 #endif /* _CXL_BUILTIN_H_ */

--- a/cxl/cxl.c
+++ b/cxl/cxl.c
@@ -195,6 +195,7 @@ static struct cmd_struct commands[] = {
 	{ "ddr-ecc-scrub-status", .c_fn = cmd_ddr_ecc_scrub_status },
 	{ "ddr-init-status", .c_fn = cmd_ddr_init_status },
 	{ "get-cxl-membridge-stats", .c_fn = cmd_get_cxl_membridge_stats },
+	{ "trigger-coredump", .c_fn = cmd_trigger_coredump },
 };
 
 int main(int argc, const char **argv)

--- a/cxl/lib/libcxl.sym
+++ b/cxl/lib/libcxl.sym
@@ -194,4 +194,5 @@ global:
     cxl_memdev_ddr_ecc_scrub_status;
     cxl_memdev_ddr_init_status;
     cxl_memdev_get_cxl_membridge_stats;
+    cxl_memdev_trigger_coredump;
 } LIBCXL_3;

--- a/cxl/libcxl.h
+++ b/cxl/libcxl.h
@@ -262,6 +262,7 @@ int cxl_memdev_start_ddr_ecc_scrub(struct cxl_memdev *memdev);
 int cxl_memdev_ddr_ecc_scrub_status(struct cxl_memdev *memdev);
 int cxl_memdev_ddr_init_status(struct cxl_memdev *memdev);
 int cxl_memdev_get_cxl_membridge_stats(struct cxl_memdev *memdev);
+int cxl_memdev_trigger_coredump(struct cxl_memdev *memdev);
 
 #define cxl_memdev_foreach(ctx, memdev) \
         for (memdev = cxl_memdev_get_first(ctx); \

--- a/cxl/memdev.c
+++ b/cxl/memdev.c
@@ -2130,6 +2130,11 @@ static const struct option cmd_get_cxl_membridge_stats_options[] = {
   OPT_END(),
 };
 
+static const struct option cmd_trigger_coredump_options[] = {
+  BASE_OPTIONS(),
+  OPT_END(),
+};
+
 static int action_cmd_clear_event_records(struct cxl_memdev *memdev, struct action_context *actx)
 {
   u16 record_handle;
@@ -4024,6 +4029,18 @@ static int action_cmd_get_cxl_membridge_stats(struct cxl_memdev *memdev,
   return cxl_memdev_get_cxl_membridge_stats(memdev);
 }
 
+static int action_cmd_trigger_coredump(struct cxl_memdev *memdev,
+                                      struct action_context *actx)
+{
+        if (cxl_memdev_is_active(memdev)) {
+                fprintf(stderr, "%s: memdev active, abort ddr-ecc-scrub-status\n",
+                        cxl_memdev_get_devname(memdev));
+                return -EBUSY;
+        }
+
+        return cxl_memdev_trigger_coredump(memdev);
+}
+
 static int action_write(struct cxl_memdev *memdev, struct action_context *actx)
 {
   size_t size = param.len, read_len;
@@ -5269,5 +5286,13 @@ int cmd_get_cxl_membridge_stats(int argc, const char **argv, struct cxl_ctx *ctx
 {
   int rc = memdev_action(argc, argv, ctx, action_cmd_get_cxl_membridge_stats, cmd_get_cxl_membridge_stats_options,
       "cxl get_cxl_membridge_errors");
+  return rc >= 0 ? 0 : EXIT_FAILURE;
+}
+
+int cmd_trigger_coredump(int argc, const char **argv, struct cxl_ctx *ctx)
+{
+  int rc = memdev_action(argc, argv, ctx, action_cmd_trigger_coredump, cmd_trigger_coredump_options,
+      "cxl trigger-coredump <mem0> [<mem1>..<memN>] [<options>]");
+
   return rc >= 0 ? 0 : EXIT_FAILURE;
 }


### PR DESCRIPTION
Test Plan:
usage: cxl trigger-coredump [..] []
-v, --verbose turn on debug

sample : ./cxl trigger-coredump mem0

Reviewers:

Subscribers:

Tasks: T175083429