### PR TITLE
Add new vendor command to enable ddr error injection

### DIFF
--- a/cxl/builtin.h
+++ b/cxl/builtin.h
@@ -140,4 +140,5 @@ int cmd_ddr_ecc_scrub_status(int argc, const char **argv, struct cxl_ctx *ctx);
 int cmd_ddr_init_status(int argc, const char **argv, struct cxl_ctx *ctx);
 int cmd_get_cxl_membridge_stats(int argc, const char **argv, struct cxl_ctx *ctx);
 int cmd_trigger_coredump(int argc, const char **argv, struct cxl_ctx *ctx);
+int cmd_ddr_err_inj_en(int argc, const char **argv, struct cxl_ctx *ctx);
 #endif /* _CXL_BUILTIN_H_ */

--- a/cxl/cxl.c
+++ b/cxl/cxl.c
@@ -196,6 +196,7 @@ static struct cmd_struct commands[] = {
 	{ "ddr-init-status", .c_fn = cmd_ddr_init_status },
 	{ "get-cxl-membridge-stats", .c_fn = cmd_get_cxl_membridge_stats },
 	{ "trigger-coredump", .c_fn = cmd_trigger_coredump },
+	{ "ddr-err-inj-en", .c_fn = cmd_ddr_err_inj_en },
 };
 
 int main(int argc, const char **argv)

--- a/cxl/lib/libcxl.c
+++ b/cxl/lib/libcxl.c
@@ -12615,3 +12615,72 @@ out:
         cxl_cmd_unref(cmd);
         return rc;
 }
+
+#define CXL_MEM_COMMAND_ID_DDR_ERR_INJ_EN CXL_MEM_COMMAND_ID_RAW
+#define CXL_MEM_COMMAND_ID_DDR_ERR_INJ_EN_OPCODE 0xFB19
+
+
+struct cxl_ddr_err_inj_en_in {
+	uint32_t ddr_id;
+	uint32_t err_type;
+} __attribute__((packed));
+
+
+CXL_EXPORT int cxl_memdev_ddr_err_inj_en(struct cxl_memdev *memdev, u32 ddr_id, u32 err_type)
+{
+	struct cxl_cmd *cmd;
+	struct cxl_mem_query_commands *query;
+	struct cxl_command_info *cinfo;
+	struct cxl_ddr_err_inj_en_in *ddr_err_inj_en_in;
+	int rc = 0;
+
+	cmd = cxl_cmd_new_raw(memdev, CXL_MEM_COMMAND_ID_DDR_ERR_INJ_EN_OPCODE);
+	if (!cmd) {
+		fprintf(stderr, "%s: cxl_cmd_new_raw returned Null output\n",
+				cxl_memdev_get_devname(memdev));
+		return -ENOMEM;
+	}
+
+	query = cmd->query_cmd;
+	cinfo = &query->commands[cmd->query_idx];
+
+	/* used to force correct payload size */
+	cinfo->size_in = CXL_MEM_COMMAND_ID_LOG_INFO_PAYLOAD_IN_SIZE;
+	if (cinfo->size_in > 0) {
+		 cmd->input_payload = calloc(1, cinfo->size_in);
+		if (!cmd->input_payload)
+			return -ENOMEM;
+		cmd->send_cmd->in.payload = (u64)cmd->input_payload;
+		cmd->send_cmd->in.size = cinfo->size_in;
+	}
+
+	ddr_err_inj_en_in = (void *) cmd->send_cmd->in.payload;
+	ddr_err_inj_en_in->ddr_id = ddr_id;
+	ddr_err_inj_en_in->err_type = err_type;
+
+	rc = cxl_cmd_submit(cmd);
+	if (rc < 0) {
+		fprintf(stderr, "%s: cmd submission failed: %d (%s)\n",
+				cxl_memdev_get_devname(memdev), rc, strerror(-rc));
+		 goto out;
+	}
+
+	rc = cxl_cmd_get_mbox_status(cmd);
+	if (rc != 0) {
+		fprintf(stderr, "%s: firmware status: %d\n",
+				cxl_memdev_get_devname(memdev), rc);
+		goto out;
+	}
+
+	if (cmd->send_cmd->id != CXL_MEM_COMMAND_ID_DDR_ERR_INJ_EN) {
+		fprintf(stderr, "%s: invalid command id 0x%x (expecting 0x%x)\n",
+				cxl_memdev_get_devname(memdev), cmd->send_cmd->id,
+				CXL_MEM_COMMAND_ID_DDR_ERR_INJ_EN);
+		return -EINVAL;
+	}
+	fprintf(stderr, "Error injection enabled on DDR%d\n", ddr_id);
+
+out:
+        cxl_cmd_unref(cmd);
+        return rc;
+}

--- a/cxl/lib/libcxl.sym
+++ b/cxl/lib/libcxl.sym
@@ -195,4 +195,5 @@ global:
     cxl_memdev_ddr_init_status;
     cxl_memdev_get_cxl_membridge_stats;
     cxl_memdev_trigger_coredump;
+    cxl_memdev_ddr_err_inj_en;
 } LIBCXL_3;

--- a/cxl/libcxl.h
+++ b/cxl/libcxl.h
@@ -263,6 +263,7 @@ int cxl_memdev_ddr_ecc_scrub_status(struct cxl_memdev *memdev);
 int cxl_memdev_ddr_init_status(struct cxl_memdev *memdev);
 int cxl_memdev_get_cxl_membridge_stats(struct cxl_memdev *memdev);
 int cxl_memdev_trigger_coredump(struct cxl_memdev *memdev);
+int cxl_memdev_ddr_err_inj_en(struct cxl_memdev *memdev, u32 ddr_id, u32 err_type);
 
 #define cxl_memdev_foreach(ctx, memdev) \
         for (memdev = cxl_memdev_get_first(ctx); \


### PR DESCRIPTION
Summary:
Add new vendor command to enable ddr error injection Enable the ddr error inection using cxl command and use read/write to device memory to inject errors

Test Plan:
 usage: cxl ddr-ecc-err-inj_en <mem0> [<mem1>..<memN>] [<options>]
 -v, --verbose         turn on debug
 -d, --ddr_id <n>      ddr id <0-DDR_CTRL0,1-DDR_CTRL1>
 -t, --err_type <n>    error type
                     0: AXI bus parity READ ADDR
                     1: AXI bus parity WRITE ADDR
                     2: AXI bus parity WRITE DATA
                     3: CA bus parity
                     4: ECC correctable
                     5: ECC uncorrectable

Error injection enabled on DDR0

Reviewers:

Subscribers:

Tasks: T169154126, D53035141

Tags: