### PR TITLE
Enhance the ddr error injection cxl command with ecc error mask

### DIFF
--- a/cxl/lib/libcxl.c
+++ b/cxl/lib/libcxl.c
@@ -12623,10 +12623,11 @@ out:
 struct cxl_ddr_err_inj_en_in {
 	uint32_t ddr_id;
 	uint32_t err_type;
+	uint64_t ecc_fwc_mask;
 } __attribute__((packed));
 
 
-CXL_EXPORT int cxl_memdev_ddr_err_inj_en(struct cxl_memdev *memdev, u32 ddr_id, u32 err_type)
+CXL_EXPORT int cxl_memdev_ddr_err_inj_en(struct cxl_memdev *memdev, u32 ddr_id, u32 err_type, u64 ecc_fwc_mask)
 {
 	struct cxl_cmd *cmd;
 	struct cxl_mem_query_commands *query;
@@ -12657,6 +12658,7 @@ CXL_EXPORT int cxl_memdev_ddr_err_inj_en(struct cxl_memdev *memdev, u32 ddr_id, 
 	ddr_err_inj_en_in = (void *) cmd->send_cmd->in.payload;
 	ddr_err_inj_en_in->ddr_id = ddr_id;
 	ddr_err_inj_en_in->err_type = err_type;
+	ddr_err_inj_en_in->ecc_fwc_mask = ecc_fwc_mask;
 
 	rc = cxl_cmd_submit(cmd);
 	if (rc < 0) {

--- a/cxl/libcxl.h
+++ b/cxl/libcxl.h
@@ -263,7 +263,7 @@ int cxl_memdev_ddr_ecc_scrub_status(struct cxl_memdev *memdev);
 int cxl_memdev_ddr_init_status(struct cxl_memdev *memdev);
 int cxl_memdev_get_cxl_membridge_stats(struct cxl_memdev *memdev);
 int cxl_memdev_trigger_coredump(struct cxl_memdev *memdev);
-int cxl_memdev_ddr_err_inj_en(struct cxl_memdev *memdev, u32 ddr_id, u32 err_type);
+int cxl_memdev_ddr_err_inj_en(struct cxl_memdev *memdev, u32 ddr_id, u32 err_type, u64 ecc_fwc_mask);
 
 #define cxl_memdev_foreach(ctx, memdev) \
         for (memdev = cxl_memdev_get_first(ctx); \

--- a/cxl/memdev.c
+++ b/cxl/memdev.c
@@ -2138,12 +2138,14 @@ static const struct option cmd_trigger_coredump_options[] = {
 static struct _ddr_err_inj_en_params {
 	u32 ddr_id;
 	u32 err_type;
+	u64 ecc_fwc_mask;
 	bool verbose;
 } ddr_err_inj_en_params;
 
 #define DDR_ERR_INJ_EN_OPTIONS() \
 OPT_UINTEGER('d', "ddr_id", &ddr_err_inj_en_params.ddr_id, "ddr id <0-DDR_CTRL0,1-DDR_CTRL1>"), \
-OPT_UINTEGER('t', "err_type", &ddr_err_inj_en_params.err_type, "error type\n\t\t\t0: AXI bus parity READ ADDR\n\t\t\t1: AXI bus parity WRITE ADDR\n\t\t\t2: AXI bus parity WRITE DATA\n\t\t\t3: CA bus parity\n\t\t\t4: ECC correctable\n\t\t\t5: ECC uncorrectable")
+OPT_UINTEGER('t', "err_type", &ddr_err_inj_en_params.err_type, "error type\n\t\t\t0: AXI bus parity READ ADDR\n\t\t\t1: AXI bus parity WRITE ADDR\n\t\t\t2: AXI bus parity WRITE DATA\n\t\t\t3: CA bus parity\n\t\t\t4: ECC correctable\n\t\t\t5: ECC uncorrectable\n\t\t\t6: ECC SCRUB"), \
+OPT_U64('m', "ecc_fwc_mask", &ddr_err_inj_en_params.ecc_fwc_mask, "ecc fwc mask <35bit value, upto two bit set for correctable ecc error\n\t\t\tAtleast 4bits for uncoorectable ecc errors\n>")
 
 static const struct option cmd_ddr_err_inj_en_options[] = {
   BASE_OPTIONS(),
@@ -4066,7 +4068,7 @@ static int action_cmd_ddr_err_inj_en(struct cxl_memdev *memdev,
 		return -EBUSY;
 	}
 
-	return cxl_memdev_ddr_err_inj_en(memdev, ddr_err_inj_en_params.ddr_id, ddr_err_inj_en_params.err_type);
+	return cxl_memdev_ddr_err_inj_en(memdev, ddr_err_inj_en_params.ddr_id, ddr_err_inj_en_params.err_type, ddr_err_inj_en_params.ecc_fwc_mask);
 }
 
 static int action_write(struct cxl_memdev *memdev, struct action_context *actx)


### PR DESCRIPTION
Summary:
Enhance the ddr error injection cxl command with ecc error mask ecc error mask is optional to introduce the error on required bits. Added option to enable ecc scrub.

Test Plan:

 -v, --verbose         turn on debug
 -d, --ddr_id <n>      ddr id <0-DDR_CTRL0,1-DDR_CTRL1>
 -t, --err_type <n>    error type
                     0: AXI bus parity READ ADDR
                     1: AXI bus parity WRITE ADDR
                     2: AXI bus parity WRITE DATA
                     3: CA bus parity
                     4: ECC correctable
                     5: ECC uncorrectable
                     6: ECC SCRUB
 -m, --ecc_fwc_mask <n>
                       ecc fwc mask <35bit value, upto two bit set for correctable ecc error
                     Atleast 4bits for uncoorectable ecc errors
Reviewers:

Subscribers:

Tasks: T173416165, D53298314

Tags: