### PR TITLE
Add vendor command to get DDR dimm level training status information

### DIFF
--- a/cxl/builtin.h
+++ b/cxl/builtin.h
@@ -143,4 +143,5 @@ int cmd_ddr_init_status(int argc, const char **argv, struct cxl_ctx *ctx);
 int cmd_get_cxl_membridge_stats(int argc, const char **argv, struct cxl_ctx *ctx);
 int cmd_trigger_coredump(int argc, const char **argv, struct cxl_ctx *ctx);
 int cmd_ddr_err_inj_en(int argc, const char **argv, struct cxl_ctx *ctx);
+int cmd_ddr_dimm_level_training_status(int argc, const char **argv, struct cxl_ctx *ctx);
 #endif /* _CXL_BUILTIN_H_ */

--- a/cxl/cxl.c
+++ b/cxl/cxl.c
@@ -199,6 +199,7 @@ static struct cmd_struct commands[] = {
 	{ "get-cxl-membridge-stats", .c_fn = cmd_get_cxl_membridge_stats },
 	{ "trigger-coredump", .c_fn = cmd_trigger_coredump },
 	{ "ddr-err-inj-en", .c_fn = cmd_ddr_err_inj_en },
+	{ "ddr-dimm-level-training-status", .c_fn = cmd_ddr_dimm_level_training_status },
 };
 
 int main(int argc, const char **argv)

--- a/cxl/lib/libcxl.sym
+++ b/cxl/lib/libcxl.sym
@@ -199,4 +199,6 @@ global:
     cxl_memdev_get_cxl_membridge_stats;
     cxl_memdev_trigger_coredump;
     cxl_memdev_ddr_err_inj_en;
+    cxl_memdev_ddr_err_inj_en;
+    cxl_memdev_ddr_dimm_level_training_status;
 } LIBCXL_3;

--- a/cxl/libcxl.h
+++ b/cxl/libcxl.h
@@ -268,6 +268,7 @@ int cxl_memdev_ddr_init_status(struct cxl_memdev *memdev);
 int cxl_memdev_get_cxl_membridge_stats(struct cxl_memdev *memdev);
 int cxl_memdev_trigger_coredump(struct cxl_memdev *memdev);
 int cxl_memdev_ddr_err_inj_en(struct cxl_memdev *memdev, u32 ddr_id, u32 err_type, u64 ecc_fwc_mask);
+int cxl_memdev_ddr_dimm_level_training_status(struct cxl_memdev *memdev);
 
 #define cxl_memdev_foreach(ctx, memdev) \
         for (memdev = cxl_memdev_get_first(ctx); \

--- a/cxl/memdev.c
+++ b/cxl/memdev.c
@@ -2184,6 +2184,11 @@ static const struct option cmd_ddr_err_inj_en_options[] = {
   OPT_END(),
 };
 
+static const struct option cmd_ddr_dimm_level_training_options[] = {
+  BASE_OPTIONS(),
+  OPT_END(),
+};
+
 static int action_cmd_clear_event_records(struct cxl_memdev *memdev, struct action_context *actx)
 {
   u16 record_handle;
@@ -4139,6 +4144,18 @@ static int action_cmd_ddr_err_inj_en(struct cxl_memdev *memdev,
 	return cxl_memdev_ddr_err_inj_en(memdev, ddr_err_inj_en_params.ddr_id, ddr_err_inj_en_params.err_type, ddr_err_inj_en_params.ecc_fwc_mask);
 }
 
+static int action_cmd_ddr_dimm_level_training_status(struct cxl_memdev *memdev,
+				      struct action_context *actx)
+{
+	if (cxl_memdev_is_active(memdev)) {
+		fprintf(stderr, "%s: memdev active, abort ddr-dimm-level-training-status\n",
+			cxl_memdev_get_devname(memdev));
+		return -EBUSY;
+	}
+
+	return cxl_memdev_ddr_dimm_level_training_status(memdev);
+}
+
 static int action_write(struct cxl_memdev *memdev, struct action_context *actx)
 {
   size_t size = param.len, read_len;
@@ -5415,6 +5432,14 @@ int cmd_ddr_err_inj_en(int argc, const char **argv, struct cxl_ctx *ctx)
 {
   int rc = memdev_action(argc, argv, ctx, action_cmd_ddr_err_inj_en, cmd_ddr_err_inj_en_options,
       "cxl ddr-err-inj-en <mem0> [<mem1>..<memN>] [<options>]");
+
+  return rc >= 0 ? 0 : EXIT_FAILURE;
+}
+
+int cmd_ddr_dimm_level_training_status(int argc, const char **argv, struct cxl_ctx *ctx)
+{
+  int rc = memdev_action(argc, argv, ctx, action_cmd_ddr_dimm_level_training_status, cmd_ddr_dimm_level_training_options,
+      "cxl ddr-dimm-level-training-status <mem0> [<mem1>..<memN>] [<options>]");
 
   return rc >= 0 ? 0 : EXIT_FAILURE;
 }


### PR DESCRIPTION
Summary:
Add vendor command to get DDR dimm level training status information

Test Plan:
./cxl/cxl ddr-dimm-level-training-status
 usage: cxl ddr-dimm-level-training-status <mem0> [<mem1>..<memN>]
 [<options>]
     -v, --verbose         turn on debug

Full log: P1189383417

Reviewers:

Subscribers:

Tasks: T173362683, D53986462

Tags: