### PR TITLE
[Vistara] Add new vendor mailbox command to get/set  ddr params and c…

### DIFF
--- a/cxl/builtin.h
+++ b/cxl/builtin.h
@@ -144,4 +144,8 @@ int cmd_get_cxl_membridge_stats(int argc, const char **argv, struct cxl_ctx *ctx
 int cmd_trigger_coredump(int argc, const char **argv, struct cxl_ctx *ctx);
 int cmd_ddr_err_inj_en(int argc, const char **argv, struct cxl_ctx *ctx);
 int cmd_ddr_dimm_level_training_status(int argc, const char **argv, struct cxl_ctx *ctx);
+int cmd_ddr_param_set(int argc, const char **argv, struct cxl_ctx *ctx);
+int cmd_ddr_param_get(int argc, const char **argv, struct cxl_ctx *ctx);
+int cmd_core_volt_set(int argc, const char **argv, struct cxl_ctx *ctx);
+int cmd_core_volt_get(int argc, const char **argv, struct cxl_ctx *ctx);
 #endif /* _CXL_BUILTIN_H_ */

--- a/cxl/cxl.c
+++ b/cxl/cxl.c
@@ -200,6 +200,10 @@ static struct cmd_struct commands[] = {
 	{ "trigger-coredump", .c_fn = cmd_trigger_coredump },
 	{ "ddr-err-inj-en", .c_fn = cmd_ddr_err_inj_en },
 	{ "ddr-dimm-level-training-status", .c_fn = cmd_ddr_dimm_level_training_status },
+	{ "ddr-param-set", .c_fn = cmd_ddr_param_set },
+	{ "ddr-param-get", .c_fn = cmd_ddr_param_get },
+	{ "core-volt-set", .c_fn = cmd_core_volt_set },
+	{ "core-volt-get", .c_fn = cmd_core_volt_get },
 };
 
 int main(int argc, const char **argv)

--- a/cxl/lib/libcxl.sym
+++ b/cxl/lib/libcxl.sym
@@ -201,4 +201,8 @@ global:
     cxl_memdev_ddr_err_inj_en;
     cxl_memdev_ddr_err_inj_en;
     cxl_memdev_ddr_dimm_level_training_status;
+    cxl_memdev_ddr_param_set;
+    cxl_memdev_ddr_param_get;
+    cxl_memdev_core_volt_set;
+    cxl_memdev_core_volt_get;
 } LIBCXL_3;

--- a/cxl/libcxl.h
+++ b/cxl/libcxl.h
@@ -269,6 +269,11 @@ int cxl_memdev_get_cxl_membridge_stats(struct cxl_memdev *memdev);
 int cxl_memdev_trigger_coredump(struct cxl_memdev *memdev);
 int cxl_memdev_ddr_err_inj_en(struct cxl_memdev *memdev, u32 ddr_id, u32 err_type, u64 ecc_fwc_mask);
 int cxl_memdev_ddr_dimm_level_training_status(struct cxl_memdev *memdev);
+int cxl_memdev_ddr_param_set(struct cxl_memdev *memdev, u32 ddr_interleave_sz,
+	u32 ddr_interleave_ctrl_choice);
+int cxl_memdev_ddr_param_get(struct cxl_memdev *memdev);
+int cxl_memdev_core_volt_set(struct cxl_memdev *memdev, float core_volt);
+int cxl_memdev_core_volt_get(struct cxl_memdev *memdev);
 
 #define cxl_memdev_foreach(ctx, memdev) \
         for (memdev = cxl_memdev_get_first(ctx); \


### PR DESCRIPTION
…ore voltage

Summary: Vendor mailbox command to  get/set  ddr params and core voltage

Test Plan: Use the ndctl cxl utility

usage: cxl ddr_param_set <mem0> [<mem1>..<memN>] [<options>]

    -v, --verbose         turn on debug

    -m, --ddr_interleave_sz <n>

                          Intereleave SZ is: 2 pow m. Input the value of m as the Size

    -n, --ddr_interleave_ctrl_choice <n>

                          CTRL Choice: 1=DDR0 2=DDR1 3= DDR0 and DDR1

sample: # ./cxl ddr-param-set -m 8 -n 3 mem0

usage: cxl ddr_param_get  <mem0> [<mem1>..<memN>] [<options>]

    -v, --verbose         turn on debug

sample: # ./cxl ddr-param-get mem0

ddr_interleave_sz: 8

ddr_interleave_ctrl_choice: 3

usage: cxl core_volt_set <mem0> [<mem1>..<memN>] [<options>]

    -v, --verbose         turn on debug

    -i, --core_volt_val1 <n>

                          CORE Voltage val1.val2 val3

    -m, --core_volt_val2 <n>

                          CORE Voltage val1.val2 val3

    -n, --core_volt_val3 <n>

                          CORE Voltage val1.val2 val3

sample: # ./cxl core-volt-set -i 0 -m 7 -n 0 mem0

usage: cxl core_volt_get  <mem0> [<mem1>..<memN>] [<options>]

    -v, --verbose         turn on debug

sample: # ./cxl core-volt-get mem0

Core Voltage: 0.700000 V

Reviewers:

Subscribers:

Tasks: T175083146, T173416209

Tags: