### PR TITLE
vistara: support pci controller error injection over vendor cci cmd

### DIFF
--- a/cxl/builtin.h
+++ b/cxl/builtin.h
@@ -152,4 +152,5 @@ int cmd_core_volt_set(int argc, const char **argv, struct cxl_ctx *ctx);
 int cmd_core_volt_get(int argc, const char **argv, struct cxl_ctx *ctx);
 int cmd_oem_err_inj_viral(int argc, const char **argv, struct cxl_ctx *ctx);
 int cmd_err_inj_ll_poison(int argc, const char **argv, struct cxl_ctx *ctx);
+int cmd_pci_err_inj(int argc, const char **argv, struct cxl_ctx *ctx);
 #endif /* _CXL_BUILTIN_H_ */

--- a/cxl/cxl.c
+++ b/cxl/cxl.c
@@ -208,6 +208,7 @@ static struct cmd_struct commands[] = {
 	{ "core-volt-get", .c_fn = cmd_core_volt_get },
 	{ "oem-err-inj-viral", .c_fn = cmd_oem_err_inj_viral },
 	{ "err-inj-ll-poison", .c_fn = cmd_err_inj_ll_poison },
+	{ "pci-err-inj", .c_fn = cmd_pci_err_inj },
 };
 
 int main(int argc, const char **argv)

--- a/cxl/lib/libcxl.c
+++ b/cxl/lib/libcxl.c
@@ -14230,3 +14230,87 @@ out:
 	return rc;
 	return 0;
 }
+
+#define CXL_MEM_COMMAND_ID_PCI_ERR_INJ CXL_MEM_COMMAND_ID_RAW
+#define CXL_MEM_COMMAND_ID_PCI_ERR_INJ_OPCODE 0xFB25
+#define CXL_MEM_COMMAND_ID_PCI_ERR_INJ_PAYLOAD_IN_SIZE 24
+
+struct cxl_mbox_pci_err_inj_in {
+	u32 en_dis;
+	u32 err_type;
+	u32 err_subtype;
+	u32 count;
+	u32 opt_param1;
+	u32 opt_param2;
+}  __attribute__((packed));
+
+
+CXL_EXPORT int cxl_memdev_pci_err_inj(struct cxl_memdev *memdev,
+	u32 en_dis,
+	u32 err_type,
+	u32 err_subtype,
+	u32 count,
+	u32 opt_param1,
+	u32 opt_param2)
+{
+	struct cxl_cmd *cmd;
+	struct cxl_mem_query_commands *query;
+	struct cxl_command_info *cinfo;
+	struct cxl_mbox_pci_err_inj_in *pci_err_inj_in;
+	int rc = 0;
+
+	cmd = cxl_cmd_new_raw(memdev, CXL_MEM_COMMAND_ID_PCI_ERR_INJ_OPCODE);
+	if (!cmd) {
+		fprintf(stderr, "%s: cxl_cmd_new_raw returned Null output\n",
+				cxl_memdev_get_devname(memdev));
+		return -ENOMEM;
+	}
+
+	query = cmd->query_cmd;
+	cinfo = &query->commands[cmd->query_idx];
+
+	/* update payload size */
+	cinfo->size_in = CXL_MEM_COMMAND_ID_PCI_ERR_INJ_PAYLOAD_IN_SIZE;
+	if (cinfo->size_in > 0) {
+		 cmd->input_payload = calloc(1, cinfo->size_in);
+		if (!cmd->input_payload)
+			return -ENOMEM;
+		cmd->send_cmd->in.payload = (u64)cmd->input_payload;
+		cmd->send_cmd->in.size = cinfo->size_in;
+	}
+
+	pci_err_inj_in = (void *) cmd->send_cmd->in.payload;
+	pci_err_inj_in->en_dis = en_dis;
+	pci_err_inj_in->err_type = err_type;
+	pci_err_inj_in->err_subtype = err_subtype;
+	pci_err_inj_in->count = count;
+	pci_err_inj_in->opt_param1 = opt_param1;
+	pci_err_inj_in->opt_param2 = opt_param2;
+
+	rc = cxl_cmd_submit(cmd);
+	if (rc < 0) {
+		fprintf(stderr, "%s: cmd submission failed: %d (%s)\n",
+				cxl_memdev_get_devname(memdev), rc, strerror(-rc));
+		 goto out;
+	}
+
+	rc = cxl_cmd_get_mbox_status(cmd);
+	if (rc != 0) {
+		fprintf(stderr, "%s: firmware status: %d:\n%s\n",
+				cxl_memdev_get_devname(memdev), rc, DEVICE_ERRORS[rc]);
+		rc = -ENXIO;
+		goto out;
+	}
+
+	if (cmd->send_cmd->id != CXL_MEM_COMMAND_ID_PCI_ERR_INJ) {
+		 fprintf(stderr, "%s: invalid command id 0x%x (expecting 0x%x)\n",
+				cxl_memdev_get_devname(memdev), cmd->send_cmd->id, CXL_MEM_COMMAND_ID_PCI_ERR_INJ);
+		return -EINVAL;
+	}
+
+
+out:
+	cxl_cmd_unref(cmd);
+	return rc;
+	return 0;
+}

--- a/cxl/lib/libcxl.sym
+++ b/cxl/lib/libcxl.sym
@@ -209,4 +209,5 @@ global:
     cxl_memdev_core_volt_get;
     cxl_memdev_oem_err_inj_viral;
     cxl_memdev_err_inj_ll_poison;
+    cxl_memdev_pci_err_inj;
 } LIBCXL_3;

--- a/cxl/libcxl.h
+++ b/cxl/libcxl.h
@@ -278,6 +278,7 @@ int cxl_memdev_core_volt_set(struct cxl_memdev *memdev, float core_volt);
 int cxl_memdev_core_volt_get(struct cxl_memdev *memdev);
 int cxl_memdev_oem_err_inj_viral(struct cxl_memdev *memdev, u32 viral_type);
 int cxl_memdev_err_inj_ll_poison(struct cxl_memdev *memdev, u32 en_dis, u32 ll_err_type);
+int cxl_memdev_pci_err_inj(struct cxl_memdev *memdev, u32 en_dis, u32 type, u32 err, u32 count, u32 opt1, u32 opt2);
 
 #define cxl_memdev_foreach(ctx, memdev) \
         for (memdev = cxl_memdev_get_first(ctx); \


### PR DESCRIPTION
Summary:
Support PCI controller error injection feature to inject various types for errors in both TX and RX directions. Error injection in RX direction(host to device LCRC/ECRC) is used to generate and test aer to host root bridge, whereas the errors in TX(device to host) path shall be detected by host root-bridge for host-side RAS test/debug.

Enable/Disable injection of various errors and verify that host is receiving the error or exception/hang.
  1. Generate PCI (IO) traffic in a loop using custom validation tool. e.g. BAR read in a loop: [root@yv3-5-vistara-2 ~]# ./pci 3f:00.0 pci device set to 0000:3f:00.0 pci-sh# pci -r 2 0 100000
  2. Enable injection of various errrors, following commands are verified: a. LCRC RX path (AER generation) cxl pci-err-inj mem0 -e 1 -l 0 -s 8 -c 0 b. DLLP TX Path:(ACK_NACK_DLLP & UPD_FC_DLLP) cxl pci-err-inj mem0 -e 1 -l 2 -s 0 -c 0 cxl pci-err-inj mem0 -e 1 -l 2 -s 1 -c 0 c. SYMBOL Err: inverted SYNC HDR (Brings down the Link) cxl pci-err-inj mem0 -e 1 -l 3 -s 0 -c 0 -x 0 -y 0 d. duplicate TLP: cxl pci-err-inj mem0 -e 1 -l 5 -s 0 -c 0 Half-Dome host hangs observed when error injected with IO traffic as RAS is not enbaled on host-side during testing. Also, observed device side error_sts interrupts to verify occurence of errors (bad-TLP error status in case of RX_LCRC)

Reviewers:

Subscribers:

Tasks: T160189746, T174057645

Tags: