### PR TITLE
Add new vendor command to read ltssm state changes

### DIFF
--- a/cxl/builtin.h
+++ b/cxl/builtin.h
@@ -153,4 +153,5 @@ int cmd_core_volt_get(int argc, const char **argv, struct cxl_ctx *ctx);
 int cmd_oem_err_inj_viral(int argc, const char **argv, struct cxl_ctx *ctx);
 int cmd_err_inj_ll_poison(int argc, const char **argv, struct cxl_ctx *ctx);
 int cmd_pci_err_inj(int argc, const char **argv, struct cxl_ctx *ctx);
+int cmd_read_ltssm_states(int argc, const char **argv, struct cxl_ctx *ctx);
 #endif /* _CXL_BUILTIN_H_ */

--- a/cxl/cxl.c
+++ b/cxl/cxl.c
@@ -209,6 +209,7 @@ static struct cmd_struct commands[] = {
 	{ "oem-err-inj-viral", .c_fn = cmd_oem_err_inj_viral },
 	{ "err-inj-ll-poison", .c_fn = cmd_err_inj_ll_poison },
 	{ "pci-err-inj", .c_fn = cmd_pci_err_inj },
+	{ "read-ltssm-states", .c_fn = cmd_read_ltssm_states },
 };
 
 int main(int argc, const char **argv)

--- a/cxl/lib/libcxl.sym
+++ b/cxl/lib/libcxl.sym
@@ -210,4 +210,5 @@ global:
     cxl_memdev_oem_err_inj_viral;
     cxl_memdev_err_inj_ll_poison;
     cxl_memdev_pci_err_inj;
+    cxl_memdev_read_ltssm_states;
 } LIBCXL_3;

--- a/cxl/libcxl.h
+++ b/cxl/libcxl.h
@@ -279,6 +279,7 @@ int cxl_memdev_core_volt_get(struct cxl_memdev *memdev);
 int cxl_memdev_oem_err_inj_viral(struct cxl_memdev *memdev, u32 viral_type);
 int cxl_memdev_err_inj_ll_poison(struct cxl_memdev *memdev, u32 en_dis, u32 ll_err_type);
 int cxl_memdev_pci_err_inj(struct cxl_memdev *memdev, u32 en_dis, u32 type, u32 err, u32 count, u32 opt1, u32 opt2);
+int cxl_memdev_read_ltssm_states(struct cxl_memdev *memdev);
 
 #define cxl_memdev_foreach(ctx, memdev) \
         for (memdev = cxl_memdev_get_first(ctx); \

--- a/cxl/memdev.c
+++ b/cxl/memdev.c
@@ -2304,6 +2304,11 @@ static const struct option cmd_pci_err_inj_options[] = {
   OPT_END(),
 };
 
+static const struct option cmd_read_ltssm_states_options[] = {
+  BASE_OPTIONS(),
+  OPT_END(),
+};
+
 static int action_cmd_clear_event_records(struct cxl_memdev *memdev, struct action_context *actx)
 {
   u16 record_handle;
@@ -4389,6 +4394,17 @@ static int action_cmd_pci_err_inj(struct cxl_memdev *memdev, struct action_conte
 				      pci_err_inj_params.opt_param2);
 }
 
+static int action_cmd_read_ltssm_states(struct cxl_memdev *memdev, struct action_context *actx)
+{
+  if (cxl_memdev_is_active(memdev)) {
+    fprintf(stderr, "%s: memdev active, abort read-ltssm-state-changes\n",
+      cxl_memdev_get_devname(memdev));
+    return -EBUSY;
+  }
+
+  return cxl_memdev_read_ltssm_states(memdev);
+}
+
 static int action_write(struct cxl_memdev *memdev, struct action_context *actx)
 {
   size_t size = param.len, read_len;
@@ -5745,6 +5761,14 @@ int cmd_pci_err_inj(int argc, const char **argv, struct cxl_ctx *ctx)
 {
   int rc = memdev_action(argc, argv, ctx, action_cmd_pci_err_inj, cmd_pci_err_inj_options,
       "cxl pci_err_inj <mem0> [<mem1>..<memN>] [<options>]");
+
+  return rc >= 0 ? 0 : EXIT_FAILURE;
+}
+
+int cmd_read_ltssm_states(int argc, const char **argv, struct cxl_ctx *ctx)
+{
+  int rc = memdev_action(argc, argv, ctx, action_cmd_read_ltssm_states, cmd_read_ltssm_states_options,
+      "cxl read-ltssm-state-changes <mem0> [<mem1>..<memN>] [<options>]");
 
   return rc >= 0 ? 0 : EXIT_FAILURE;
 }


### PR DESCRIPTION
Summary:
Add new vendor command to read ltssm states

Test Plan:
./cxl/cxl read-ltssm-states mem0
LTSSM STATE CHANGES
ltssm state val = 0x1, DETECT_ACT
ltssm state val = 0x2, POLL_ACTIVE
ltssm state val = 0x4, POLL_CONFIG
ltssm state val = 0x7, CFG_LINKWD_START
ltssm state val = 0x9, CFG_LANENUM_WAIT
ltssm state val = 0xb, CFG_COMPLETE
ltssm state val = 0xc, CFG_IDLE
ltssm state val = 0xf, RCVRY_RCVRCFG
ltssm state val = 0xe, RCVRY_SPEED
ltssm state val = 0x20, RCVRY_EQ0
ltssm state val = 0x21, RCVRY_EQ1
ltssm state val = 0x22, RCVRY_EQ2
ltssm state val = 0x23, RCVRY_EQ3
ltssm state val = 0xf, RCVRY_RCVRCFG
ltssm state val = 0xd, RCVRY_LOCK
ltssm state val = 0xf, RCVRY_RCVRCFG
ltssm state val = 0xe, RCVRY_SPEED
ltssm state val = 0x20, RCVRY_EQ0
ltssm state val = 0x21, RCVRY_EQ1
ltssm state val = 0x22, RCVRY_EQ2
ltssm state val = 0x23, RCVRY_EQ3
ltssm state val = 0x10, RCVRY_IDLE
ltssm state val = 0xf, RCVRY_RCVRCFG
ltssm state val = 0xe, RCVRY_SPEED
ltssm state val = 0x20, RCVRY_EQ0
ltssm state val = 0x21, RCVRY_EQ1
ltssm state val = 0x22, RCVRY_EQ2
ltssm state val = 0x23, RCVRY_EQ3
ltssm state val = 0x11, L0
ltssm state val = 0xf, RCVRY_RCVRCFG
ltssm state val = 0x11, L0
ltssm state val = 0xf, RCVRY_RCVRCFG
ltssm state val = 0x11, L0

Reviewers:

Subscribers:

Tasks: T174057566, D55786481

Tags: