### PR TITLE
vistara: Add Mailbox Command to set the page policy

### DIFF
--- a/cxl/builtin.h
+++ b/cxl/builtin.h
@@ -154,4 +154,6 @@ int cmd_oem_err_inj_viral(int argc, const char **argv, struct cxl_ctx *ctx);
 int cmd_err_inj_ll_poison(int argc, const char **argv, struct cxl_ctx *ctx);
 int cmd_pci_err_inj(int argc, const char **argv, struct cxl_ctx *ctx);
 int cmd_read_ltssm_states(int argc, const char **argv, struct cxl_ctx *ctx);
+int cmd_ddr_page_select_set(int argc, const char **argv, struct cxl_ctx *ctx);
+int cmd_ddr_page_select_get(int argc, const char **argv, struct cxl_ctx *ctx);
 #endif /* _CXL_BUILTIN_H_ */

--- a/cxl/cxl.c
+++ b/cxl/cxl.c
@@ -210,6 +210,8 @@ static struct cmd_struct commands[] = {
 	{ "err-inj-ll-poison", .c_fn = cmd_err_inj_ll_poison },
 	{ "pci-err-inj", .c_fn = cmd_pci_err_inj },
 	{ "read-ltssm-states", .c_fn = cmd_read_ltssm_states },
+	{ "ddr-page-select-set", .c_fn = cmd_ddr_page_select_set },
+	{ "ddr-page-select-get", .c_fn = cmd_ddr_page_select_get },
 };
 
 int main(int argc, const char **argv)

--- a/cxl/lib/libcxl.c
+++ b/cxl/lib/libcxl.c
@@ -14400,3 +14400,144 @@ out:
 	return rc;
 	return 0;
 }
+
+/* DDR PAGE SELECT SET */
+#define CXL_MEM_COMMAND_ID_DDR_PAGE_SELECT_SET CXL_MEM_COMMAND_ID_RAW
+#define CXL_MEM_COMMAND_ID_DDR_PAGE_SELECT_SET_OPCODE 0xFB2A
+#define CXL_MEM_COMMAND_ID_DDR_PAGE_SELECT_SET_PAYLOAD_IN_SIZE 4
+
+struct page_policy_selection {
+    uint8_t page_policy_reg_val;
+} __attribute__((packed)) page_policy_select;
+
+
+struct cxl_mbox_handle_page_selection_in {
+  struct page_policy_selection pp_select;
+} __attribute__((packed));
+
+
+
+CXL_EXPORT int cxl_memdev_ddr_page_select_set(struct cxl_memdev *memdev,
+                 u32 page_select_option)
+{
+    struct cxl_cmd *cmd;
+    struct cxl_mem_query_commands *query;
+    struct cxl_command_info *cinfo;
+    struct cxl_mbox_handle_page_selection_in *handle_page_selection_in;
+    int rc = 0;
+
+    cmd = cxl_cmd_new_raw(memdev, CXL_MEM_COMMAND_ID_DDR_PAGE_SELECT_SET_OPCODE);
+    if (!cmd) {
+        fprintf(stderr, "%s: cxl_cmd_new_raw returned Null output\n",
+                cxl_memdev_get_devname(memdev));
+        return -ENOMEM;
+    }
+
+    query = cmd->query_cmd;
+    cinfo = &query->commands[cmd->query_idx];
+
+    /* update payload size */
+    cinfo->size_in = CXL_MEM_COMMAND_ID_DDR_PAGE_SELECT_SET_PAYLOAD_IN_SIZE;
+    if (cinfo->size_in > 0) {
+        cmd->input_payload = calloc(1, cinfo->size_in);
+        if (!cmd->input_payload)
+            return -ENOMEM;
+        cmd->send_cmd->in.payload = (u64)cmd->input_payload;
+        cmd->send_cmd->in.size = cinfo->size_in;
+    }
+
+    handle_page_selection_in = (void *) cmd->send_cmd->in.payload;
+
+    handle_page_selection_in->pp_select.page_policy_reg_val = page_select_option;
+
+    rc = cxl_cmd_submit(cmd);
+    if (rc < 0) {
+        fprintf(stderr, "%s: cmd submission failed: %d (%s)\n",
+                cxl_memdev_get_devname(memdev), rc, strerror(-rc));
+        goto out;
+    }
+
+    rc = cxl_cmd_get_mbox_status(cmd);
+    if (rc != 0) {
+        fprintf(stderr, "%s: firmware status: %d\n",
+                cxl_memdev_get_devname(memdev), rc);
+        rc = -ENXIO;
+        goto out;
+    }
+
+    if (cmd->send_cmd->id != CXL_MEM_COMMAND_ID_DDR_PAGE_SELECT_SET) {
+        fprintf(stderr, "%s: invalid command id 0x%x (expecting 0x%x)\n",
+                cxl_memdev_get_devname(memdev), cmd->send_cmd->id,
+                CXL_MEM_COMMAND_ID_DDR_PAGE_SELECT_SET);
+        return -EINVAL;
+    }
+
+out:
+    cxl_cmd_unref(cmd);
+    return rc;
+}
+
+/* DDR PAGE SELECT GET */
+#define CXL_MEM_COMMAND_ID_CXL_DDR_PAGE_SELECT_GET CXL_MEM_COMMAND_ID_RAW
+#define CXL_MEM_COMMAND_ID_CXL_DDR_PAGE_SELECT_GET_OPCODE 0xFB2B
+
+struct cxl_mbox_handle_page_selection_out {
+  struct page_policy_selection pp_select;
+} __attribute__((packed));
+
+CXL_EXPORT int cxl_memdev_ddr_page_select_get(struct cxl_memdev *memdev)
+{
+    struct cxl_cmd *cmd;
+    struct cxl_mem_query_commands *query;
+    struct cxl_command_info *cinfo;
+    struct cxl_mbox_handle_page_selection_out *handle_page_selection_out;
+    int rc = 0;
+
+    cmd = cxl_cmd_new_raw(memdev, CXL_MEM_COMMAND_ID_CXL_DDR_PAGE_SELECT_GET_OPCODE);
+    if (!cmd) {
+        fprintf(stderr, "%s: cxl_cmd_new_raw returned Null output\n",
+                cxl_memdev_get_devname(memdev));
+        return -ENOMEM;
+    }
+
+    query = cmd->query_cmd;
+    cinfo = &query->commands[cmd->query_idx];
+
+    /* used to force correct payload size */
+    cinfo->size_in = CXL_MEM_COMMAND_ID_LOG_INFO_PAYLOAD_IN_SIZE;
+    if (cinfo->size_in > 0) {
+        cmd->input_payload = calloc(1, cinfo->size_in);
+        if (!cmd->input_payload)
+            return -ENOMEM;
+        cmd->send_cmd->in.payload = (u64)cmd->input_payload;
+        cmd->send_cmd->in.size = cinfo->size_in;
+    }
+
+    rc = cxl_cmd_submit(cmd);
+    if (rc < 0) {
+        fprintf(stderr, "%s: cmd submission failed: %d (%s)\n",
+                cxl_memdev_get_devname(memdev), rc, strerror(-rc));
+        goto out;
+    }
+
+    rc = cxl_cmd_get_mbox_status(cmd);
+    if (rc != 0) {
+        fprintf(stderr, "%s: firmware status: %d\n",
+                cxl_memdev_get_devname(memdev), rc);
+        goto out;
+    }
+
+    if (cmd->send_cmd->id != CXL_MEM_COMMAND_ID_CXL_DDR_PAGE_SELECT_GET) {
+        fprintf(stderr, "%s: invalid command id 0x%x (expecting 0x%x)\n",
+                cxl_memdev_get_devname(memdev), cmd->send_cmd->id,
+                CXL_MEM_COMMAND_ID_CXL_DDR_PAGE_SELECT_GET);
+        return -EINVAL;
+    }
+
+    handle_page_selection_out = (struct cxl_mbox_handle_page_selection_out *)cmd->send_cmd->out.payload;
+    fprintf(stdout, "Page_Policy_Reg_Value is selected for %s\n", (handle_page_selection_out->pp_select.page_policy_reg_val)?"open":"close");
+
+out:
+    cxl_cmd_unref(cmd);
+    return rc;
+}

--- a/cxl/lib/libcxl.sym
+++ b/cxl/lib/libcxl.sym
@@ -211,4 +211,6 @@ global:
     cxl_memdev_err_inj_ll_poison;
     cxl_memdev_pci_err_inj;
     cxl_memdev_read_ltssm_states;
+    cxl_memdev_ddr_page_select_set;
+    cxl_memdev_ddr_page_select_get;
 } LIBCXL_3;

--- a/cxl/libcxl.h
+++ b/cxl/libcxl.h
@@ -280,6 +280,8 @@ int cxl_memdev_oem_err_inj_viral(struct cxl_memdev *memdev, u32 viral_type);
 int cxl_memdev_err_inj_ll_poison(struct cxl_memdev *memdev, u32 en_dis, u32 ll_err_type);
 int cxl_memdev_pci_err_inj(struct cxl_memdev *memdev, u32 en_dis, u32 type, u32 err, u32 count, u32 opt1, u32 opt2);
 int cxl_memdev_read_ltssm_states(struct cxl_memdev *memdev);
+int cxl_memdev_ddr_page_select_set(struct cxl_memdev *memdev, u32 page_select_option);
+int cxl_memdev_ddr_page_select_get(struct cxl_memdev *memdev);
 
 #define cxl_memdev_foreach(ctx, memdev) \
         for (memdev = cxl_memdev_get_first(ctx); \


### PR DESCRIPTION
Summary:
Add support for DDR page selection feature

This commit introduces support for the DDR page selection feature

Changes:
-Introduced cmd_ddr_page_select_set and cmd_ddr_page_select_get functions for managing DDR page selection options. -Implemented cxl commands ddr-page-select-set and ddr-page-select-get. -Implemented cxl_memdev_ddr_page_select_set and cxl_memdev_ddr_page_select_get functions for memory device interaction. -Added command line options and parsing for ddr-page-select-set and ddr-page-select-get.

Test Plan:
step 1:
-Erase the QSPI flash and update the boot2 image. By default, it is necessary to select the closed-page policy configuration. -To confirm this, execute the following command in the UART console. It should give the output as follows: $ vtmon nv 5
PAGE_SELECT_POLICY IS SELECTED TO CLOSE
Step 2:
-Write the value to the QSPI flash using the ndctl command. It will take effect from the next power cycle onwards. Execute the following command from the Vistara host console: $./cxl ddr-page-select-set -p 1 mem0
The above command will set the register configuration value for the page policy registers. $Option -p 0 indicates the closed-page policy, while option -p 1 indicates the open-page policy. -Read the value back using the following command on the Vistara host console: $./cxl ddr-page-select-get mem0
page_policy_reg_value is selected for open
-Also, read it from the boot2 UART console using the following command: $ vtmon nv 5
Option 5 is to read the value for the page-register policy -To set the value in the boot2 UART console, use the following command: $vtmon nv 5 1
Here, option 1 selects the open-page policy, while option 0 selects the closed-page policy. -To read it back from the UART console, use the following command: $vtmon nv 5
PAGE_SELECT_POLICY IS SELECTED TO OPEN

-Execute the mlc binary to get the latency of the device: Below attached the sample output of open and close page policy.

Open page policy output:
[root@vistara8-bv97421 Linux]# ./mlc
Intel(R) Memory Latency Checker - v3.9a

*************   Hugepages need to be allocated using /proc/sys/vm/nr_hugepages ******
*************   Without large pages, the latencies are not accurate
*************   We need at least 500 2M pages per numa node
*************   Execute the following and re-run
*************   echo 4000 > /proc/sys/vm/nr_hugepages
[root@vistara8-bv97421 Linux]# echo 4000 > /proc/sys/vm/nr_hugepages
[root@vistara8-bv97421 Linux]# ./mlc
Intel(R) Memory Latency Checker - v3.9a
[  107.675113] msr: Write to unrecognized MSR 0xc0000108 by mlc (pid: 2190).
[  107.690194] msr: See https://git.kernel.org/pub/scm/linux/kernel/git/tip/tip.git/about for details.
Measuring idle latencies (in ns)...
		Numa node
Numa node	     0	     1
       0	 126.3	 271.3

close page policy output:
[root@vistara8-bv97421 Linux]# ./mlc
Intel(R) Memory Latency Checker - v3.9a
[  511.880440] msr: Write to unrecognized MSR 0xc0000108 by mlc (pid: 4882). [  511.895522] msr: See https://git.kernel.org/pub/scm/linux/kernel/git/tip/tip.git/about for details. [  511.915785] systemd-journald[1383]: Sent WATCHDOG=1 notification. Measuring idle latencies (in ns)...
		Numa node
Numa node	     0	     1
       0	 124.9	 261.8

Reviewers: @raveendrapa-meta @sandeepa-prabhu-meta @praveenkb-meta @Shreesha-Rajashekar @arjunjy-meta

Subscribers:

Tasks:T174057484

Tags: