### PR TITLE
Vistara: Add mailbox command for the DDR Refresh Mode

### DIFF
--- a/cxl/builtin.h
+++ b/cxl/builtin.h
@@ -162,4 +162,6 @@ int cmd_ddr_hppr_addr_info_set(int argc, const char **argv, struct cxl_ctx *ctx)
 int cmd_ddr_hppr_addr_info_get(int argc, const char **argv, struct cxl_ctx *ctx);
 int cmd_ddr_hppr_addr_info_clear(int argc, const char **argv, struct cxl_ctx *ctx);
 int cmd_ddr_ppr_status_get(int argc, const char **argv, struct cxl_ctx *ctx);
+int cmd_ddr_refresh_mode_set(int argc, const char **argv, struct cxl_ctx *ctx);
+int cmd_ddr_refresh_mode_get(int argc, const char **argv, struct cxl_ctx *ctx);
 #endif /* _CXL_BUILTIN_H_ */

--- a/cxl/cxl.c
+++ b/cxl/cxl.c
@@ -218,6 +218,8 @@ static struct cmd_struct commands[] = {
 	{ "ddr-hppr-addr-info-get", .c_fn = cmd_ddr_hppr_addr_info_get },
 	{ "ddr-hppr-addr-info-clear", .c_fn = cmd_ddr_hppr_addr_info_clear },
 	{ "ddr-ppr-status-get", .c_fn = cmd_ddr_ppr_status_get },
+	{ "ddr-refresh-mode-set", .c_fn = cmd_ddr_refresh_mode_set },
+	{ "ddr-refresh-mode-get", .c_fn = cmd_ddr_refresh_mode_get },
 };
 
 int main(int argc, const char **argv)

--- a/cxl/lib/libcxl.sym
+++ b/cxl/lib/libcxl.sym
@@ -219,4 +219,6 @@ global:
     cxl_memdev_ddr_hppr_addr_info_get;
     cxl_memdev_ddr_hppr_addr_info_clear;
     cxl_memdev_ddr_ppr_status_get;
+    cxl_memdev_ddr_refresh_mode_set;
+    cxl_memdev_ddr_refresh_mode_get;
 } LIBCXL_3;

--- a/cxl/libcxl.h
+++ b/cxl/libcxl.h
@@ -288,6 +288,8 @@ int cxl_memdev_ddr_hppr_addr_info_set(struct cxl_memdev *memdev, u8 ddr_id, u8 c
 int cxl_memdev_ddr_hppr_addr_info_get(struct cxl_memdev *memdev);
 int cxl_memdev_ddr_hppr_addr_info_clear(struct cxl_memdev *memdev, u8 ddr_id, u8 channel_id);
 int cxl_memdev_ddr_ppr_status_get(struct cxl_memdev *memdev);
+int cxl_memdev_ddr_refresh_mode_set(struct cxl_memdev *memdev, u8 refresh_select_option);
+int cxl_memdev_ddr_refresh_mode_get(struct cxl_memdev *memdev);
 
 #define cxl_memdev_foreach(ctx, memdev) \
         for (memdev = cxl_memdev_get_first(ctx); \


### PR DESCRIPTION
Summary:
-Added new commands for setting and getting DDR refresh mode in `cxl` library.
- Implemented the functions in `cxl/lib/libcxl.c` to handle DDR refresh mode mailbox commands.
- Updated command structures in `cxl/cxl.c` to include the new commands.

Test Plan:
- Implemented the uart shell command to get the refresh mode - Execute the below command to get the ddr refresh mode from uart uart:~$ vtmon nv 6 REFRESH MODE IS SELECTED TO 2xRefresh Mode uart:~$ vtmon nv 6 0 uart:~$ vtmon nv 6 REFRESH MODE IS SELECTED TO 1xRefresh Mode Note( By default refresh mode is selected to 1x refresh mode) change the refresh mode by writing value after vtmon nv 6 value 0 - 1x Refresh mode value 2 - 2x Refresh mode value 4 - 4x refresh mode

    -Implemented the ndctl command to verify
    -Execute the below command to get the ddr refresh mode from host machine
     [root@vistara10-ch73403 cxl]# ./cxl ddr-refresh-mode-get mem0
     REFRESH MODE IS SELECTED TO 1xRefresh mode

     [root@vistara10-ch73403 cxl]# ./cxl ddr-refresh-mode-set -r 0  mem0
     [root@vistara10-ch73403 cxl]# ./cxl ddr-refresh-mode-get mem0
     REFRESH MODE IS SELECTED TO 1xRefresh mode
     [root@vistara10-ch73403 cxl]# ./cxl ddr-refresh-mode-set -r 4  mem0
     [root@vistara10-ch73403 cxl]# ./cxl ddr-refresh-mode-get mem0
     REFRESH MODE IS SELECTED TO 4xRefresh mode
     [root@vistara10-ch73403 cxl]# ./cxl ddr-refresh-mode-set -r 2  mem0
     [root@vistara10-ch73403 cxl]# ./cxl ddr-refresh-mode-get mem0
     REFRESH MODE IS SELECTED TO 2xRefresh mode

    -Refresh mode should sustain after the reboot also.

Reviewers:

Subscribers:

Tasks: T174715111

Tags: