### PR TITLE
Vistara: Add CXL command support for DDR hPPR feature

### DIFF
--- a/cxl/builtin.h
+++ b/cxl/builtin.h
@@ -156,4 +156,10 @@ int cmd_pci_err_inj(int argc, const char **argv, struct cxl_ctx *ctx);
 int cmd_read_ltssm_states(int argc, const char **argv, struct cxl_ctx *ctx);
 int cmd_ddr_page_select_set(int argc, const char **argv, struct cxl_ctx *ctx);
 int cmd_ddr_page_select_get(int argc, const char **argv, struct cxl_ctx *ctx);
+int cmd_ddr_hppr_set(int argc, const char **argv, struct cxl_ctx *ctx);
+int cmd_ddr_hppr_get(int argc, const char **argv, struct cxl_ctx *ctx);
+int cmd_ddr_hppr_addr_info_set(int argc, const char **argv, struct cxl_ctx *ctx);
+int cmd_ddr_hppr_addr_info_get(int argc, const char **argv, struct cxl_ctx *ctx);
+int cmd_ddr_hppr_addr_info_clear(int argc, const char **argv, struct cxl_ctx *ctx);
+int cmd_ddr_ppr_status_get(int argc, const char **argv, struct cxl_ctx *ctx);
 #endif /* _CXL_BUILTIN_H_ */

--- a/cxl/cxl.c
+++ b/cxl/cxl.c
@@ -212,6 +212,12 @@ static struct cmd_struct commands[] = {
 	{ "read-ltssm-states", .c_fn = cmd_read_ltssm_states },
 	{ "ddr-page-select-set", .c_fn = cmd_ddr_page_select_set },
 	{ "ddr-page-select-get", .c_fn = cmd_ddr_page_select_get },
+	{ "ddr-hppr-set", .c_fn = cmd_ddr_hppr_set },
+	{ "ddr-hppr-get", .c_fn = cmd_ddr_hppr_get },
+	{ "ddr-hppr-addr-info-set", .c_fn = cmd_ddr_hppr_addr_info_set },
+	{ "ddr-hppr-addr-info-get", .c_fn = cmd_ddr_hppr_addr_info_get },
+	{ "ddr-hppr-addr-info-clear", .c_fn = cmd_ddr_hppr_addr_info_clear },
+	{ "ddr-ppr-status-get", .c_fn = cmd_ddr_ppr_status_get },
 };
 
 int main(int argc, const char **argv)

--- a/cxl/lib/libcxl.sym
+++ b/cxl/lib/libcxl.sym
@@ -213,4 +213,10 @@ global:
     cxl_memdev_read_ltssm_states;
     cxl_memdev_ddr_page_select_set;
     cxl_memdev_ddr_page_select_get;
+    cxl_memdev_ddr_hppr_set;
+    cxl_memdev_ddr_hppr_get;
+    cxl_memdev_ddr_hppr_addr_info_set;
+    cxl_memdev_ddr_hppr_addr_info_get;
+    cxl_memdev_ddr_hppr_addr_info_clear;
+    cxl_memdev_ddr_ppr_status_get;
 } LIBCXL_3;

--- a/cxl/libcxl.h
+++ b/cxl/libcxl.h
@@ -282,6 +282,12 @@ int cxl_memdev_pci_err_inj(struct cxl_memdev *memdev, u32 en_dis, u32 type, u32 
 int cxl_memdev_read_ltssm_states(struct cxl_memdev *memdev);
 int cxl_memdev_ddr_page_select_set(struct cxl_memdev *memdev, u32 page_select_option);
 int cxl_memdev_ddr_page_select_get(struct cxl_memdev *memdev);
+int cxl_memdev_ddr_hppr_set(struct cxl_memdev *memdev, u8 hppr_enable_option);
+int cxl_memdev_ddr_hppr_get(struct cxl_memdev *memdev);
+int cxl_memdev_ddr_hppr_addr_info_set(struct cxl_memdev *memdev, u8 ddr_id, u8 chip_select, u8 bank_group, u8 bank, u32 row);
+int cxl_memdev_ddr_hppr_addr_info_get(struct cxl_memdev *memdev);
+int cxl_memdev_ddr_hppr_addr_info_clear(struct cxl_memdev *memdev, u8 ddr_id, u8 channel_id);
+int cxl_memdev_ddr_ppr_status_get(struct cxl_memdev *memdev);
 
 #define cxl_memdev_foreach(ctx, memdev) \
         for (memdev = cxl_memdev_get_first(ctx); \

--- a/cxl/memdev.c
+++ b/cxl/memdev.c
@@ -2327,6 +2327,84 @@ static const struct option cmd_ddr_page_select_get_options[] = {
   OPT_END(),
 };
 
+static struct _ddr_hppr_set_params {
+  u32 enable;
+} ddr_hppr_set_params;
+
+#define DDR_HPPR_SET_OPTIONS() \
+  OPT_UINTEGER('e', "ddr_hppr_en", &ddr_hppr_set_params.enable, "HPPR Enable/Disable value(1/0)")
+
+static const struct option cmd_ddr_hppr_set_options[] = {
+  BASE_OPTIONS(),
+  DDR_HPPR_SET_OPTIONS(),
+  OPT_END(),
+};
+
+static const struct option cmd_ddr_hppr_get_options[] = {
+  BASE_OPTIONS(),
+  OPT_END(),
+};
+
+struct _ddr_hppr_addr_info_set_params {
+  u32 ddr_id;
+  u32 chip_select; /* 2bit chip select info of faulty row*/
+  u32 bank; /* 2bits bank info*/
+  u32 bank_group; /* 2bit bank group info */
+  u32 row; /* faulty row address */
+} ddr_hppr_addr_info_set_params;
+
+struct _ddr_addr_info {
+  u32 ddr_id;
+  u32 chip_select; /* 2bit chip select info of faulty row*/
+  u32 bank; /* 2bits bank info*/
+  u32 bank_group; /* 2bit bank group info */
+  u32 row; /* faulty row address */
+  u32 channel; /* channel 0/1 of DDR controller */
+  u32 ppr_state;
+} ddr_addr_info;
+
+struct _ddr_hppr_addr_info_get_params {
+  struct _ddr_addr_info addr_info[2][8];
+} ddr_hppr_addr_info_get_params;
+
+#define DDR_HPPR_ADDR_INFO_SET_OPTIONS() \
+  OPT_UINTEGER('d', "ddr_id", &ddr_hppr_addr_info_set_params.ddr_id, "HPPR addr info: DDR controller ID value"), \
+  OPT_UINTEGER('c', "chip_select", &ddr_hppr_addr_info_set_params.chip_select, "HPPR addr info: chip select value"), \
+  OPT_UINTEGER('g', "bank_group", &ddr_hppr_addr_info_set_params.bank_group, "HPPR addr info: bank group value"), \
+  OPT_UINTEGER('b', "bank", &ddr_hppr_addr_info_set_params.bank, "HPPR addr info: bank value"), \
+  OPT_UINTEGER('r', "row", &ddr_hppr_addr_info_set_params.row, "HPPR addr info: row value")
+
+static const struct option cmd_ddr_hppr_addr_info_set_options[] = {
+  BASE_OPTIONS(),
+  DDR_HPPR_ADDR_INFO_SET_OPTIONS(),
+  OPT_END(),
+};
+
+static const struct option cmd_ddr_hppr_addr_info_get_options[] = {
+  BASE_OPTIONS(),
+  OPT_END(),
+};
+
+struct _ddr_hppr_addr_info_clear_params {
+  u32 ddr_id;
+  u32 channel_id;
+} ddr_hppr_addr_info_clear_params;
+
+#define DDR_HPPR_ADDR_INFO_CLEAR_OPTIONS() \
+  OPT_UINTEGER('d', "ddr_id", &ddr_hppr_addr_info_clear_params.ddr_id, "HPPR addr info: DDR controller ID value"), \
+  OPT_UINTEGER('c', "channel_id", &ddr_hppr_addr_info_clear_params.channel_id, "HPPR addr info: channel ID value")
+
+static const struct option cmd_ddr_hppr_addr_info_clear_options[] = {
+  BASE_OPTIONS(),
+  DDR_HPPR_ADDR_INFO_CLEAR_OPTIONS(),
+  OPT_END(),
+};
+
+static const struct option cmd_ddr_ppr_status_get_options[] = {
+  BASE_OPTIONS(),
+  OPT_END(),
+};
+
 static int action_cmd_clear_event_records(struct cxl_memdev *memdev, struct action_context *actx)
 {
   u16 record_handle;
@@ -4448,6 +4526,77 @@ static int action_cmd_ddr_page_select_get(struct cxl_memdev *memdev,
 	return cxl_memdev_ddr_page_select_get(memdev);
 }
 
+static int action_cmd_ddr_hppr_set(struct cxl_memdev *memdev,
+				      struct action_context *actx)
+{
+	if (cxl_memdev_is_active(memdev)) {
+		fprintf(stderr, "%s: memdev active, abort ddr_hppr_set\n",
+			cxl_memdev_get_devname(memdev));
+		return -EBUSY;
+	}
+
+	return cxl_memdev_ddr_hppr_set(memdev, ddr_hppr_set_params.enable);
+}
+
+static int action_cmd_ddr_hppr_get(struct cxl_memdev *memdev,
+				      struct action_context *actx)
+{
+	if (cxl_memdev_is_active(memdev)) {
+		fprintf(stderr, "%s: memdev active, abort ddr_hppr_get\n",
+			cxl_memdev_get_devname(memdev));
+		return -EBUSY;
+	}
+
+	return cxl_memdev_ddr_hppr_get(memdev);
+}
+
+static int action_cmd_ddr_hppr_addr_info_set(struct cxl_memdev *memdev,
+				      struct action_context *actx)
+{
+	if (cxl_memdev_is_active(memdev)) {
+		fprintf(stderr, "%s: memdev active, abort ddr_hppr_addr_info_set\n",
+			cxl_memdev_get_devname(memdev));
+		return -EBUSY;
+	}
+
+	return cxl_memdev_ddr_hppr_addr_info_set(memdev, ddr_hppr_addr_info_set_params.ddr_id, ddr_hppr_addr_info_set_params.chip_select, ddr_hppr_addr_info_set_params.bank_group, ddr_hppr_addr_info_set_params.bank, ddr_hppr_addr_info_set_params.row);
+}
+
+static int action_cmd_ddr_hppr_addr_info_get(struct cxl_memdev *memdev,
+				      struct action_context *actx)
+{
+	if (cxl_memdev_is_active(memdev)) {
+		fprintf(stderr, "%s: memdev active, abort ddr_hppr_addr_info_get\n",
+			cxl_memdev_get_devname(memdev));
+		return -EBUSY;
+	}
+
+	return cxl_memdev_ddr_hppr_addr_info_get(memdev);
+}
+
+static int action_cmd_ddr_hppr_addr_info_clear(struct cxl_memdev *memdev,
+				      struct action_context *actx)
+{
+	if (cxl_memdev_is_active(memdev)) {
+		fprintf(stderr, "%s: memdev active, abort ddr_hppr_info_clear\n",
+			cxl_memdev_get_devname(memdev));
+		return -EBUSY;
+	}
+
+	return cxl_memdev_ddr_hppr_addr_info_clear(memdev, ddr_hppr_addr_info_clear_params.ddr_id, ddr_hppr_addr_info_clear_params.channel_id);
+}
+
+static int action_cmd_ddr_ppr_status_get(struct cxl_memdev *memdev,
+				      struct action_context *actx)
+{
+	if (cxl_memdev_is_active(memdev)) {
+		fprintf(stderr, "%s: memdev active, abort ddr_ppr_status_get\n",
+			cxl_memdev_get_devname(memdev));
+		return -EBUSY;
+	}
+
+	return cxl_memdev_ddr_ppr_status_get(memdev);
+}
 
 static int action_write(struct cxl_memdev *memdev, struct action_context *actx)
 {
@@ -5829,6 +5978,54 @@ int cmd_ddr_page_select_get(int argc, const char **argv, struct cxl_ctx *ctx)
 {
   int rc = memdev_action(argc, argv, ctx, action_cmd_ddr_page_select_get, cmd_ddr_page_select_get_options,
       "cxl ddr-page-select-get <mem0> [<mem1>..<memN>] [<options>]");
+
+  return rc >= 0 ? 0 : EXIT_FAILURE;
+}
+
+int cmd_ddr_hppr_set(int argc, const char **argv, struct cxl_ctx *ctx)
+{
+  int rc = memdev_action(argc, argv, ctx, action_cmd_ddr_hppr_set, cmd_ddr_hppr_set_options,
+      "cxl ddr-hppr-set <<mem0> [<mem1>..<memN>] [<options>]");
+
+  return rc >= 0 ? 0 : EXIT_FAILURE;
+}
+
+int cmd_ddr_hppr_get(int argc, const char **argv, struct cxl_ctx *ctx)
+{
+  int rc = memdev_action(argc, argv, ctx, action_cmd_ddr_hppr_get, cmd_ddr_hppr_get_options,
+      "cxl ddr-hppr-get <mem0> [<mem1>..<memN>] [<options>]");
+
+  return rc >= 0 ? 0 : EXIT_FAILURE;
+}
+
+int cmd_ddr_hppr_addr_info_set(int argc, const char **argv, struct cxl_ctx *ctx)
+{
+  int rc = memdev_action(argc, argv, ctx, action_cmd_ddr_hppr_addr_info_set, cmd_ddr_hppr_addr_info_set_options,
+      "cxl ddr-hppr-addr-info-set <<mem0> [<mem1>..<memN>] [<options>]");
+
+  return rc >= 0 ? 0 : EXIT_FAILURE;
+}
+
+int cmd_ddr_hppr_addr_info_get(int argc, const char **argv, struct cxl_ctx *ctx)
+{
+  int rc = memdev_action(argc, argv, ctx, action_cmd_ddr_hppr_addr_info_get, cmd_ddr_hppr_addr_info_get_options,
+      "cxl ddr-hppr-addr-info-get <mem0> [<mem1>..<memN>] [<options>]");
+
+  return rc >= 0 ? 0 : EXIT_FAILURE;
+}
+
+int cmd_ddr_hppr_addr_info_clear(int argc, const char **argv, struct cxl_ctx *ctx)
+{
+  int rc = memdev_action(argc, argv, ctx, action_cmd_ddr_hppr_addr_info_clear, cmd_ddr_hppr_addr_info_clear_options,
+      "cxl ddr-hppr-addr-info-clear <<mem0> [<mem1>..<memN>] [<options>]");
+
+  return rc >= 0 ? 0 : EXIT_FAILURE;
+}
+
+int cmd_ddr_ppr_status_get(int argc, const char **argv, struct cxl_ctx *ctx)
+{
+  int rc = memdev_action(argc, argv, ctx, action_cmd_ddr_ppr_status_get, cmd_ddr_ppr_status_get_options,
+      "cxl ddr-ppr-status-get <mem0> [<mem1>..<memN>] [<options>]");
 
   return rc >= 0 ? 0 : EXIT_FAILURE;
 }


### PR DESCRIPTION
**Summary:** Vistara: Add CXL command support for DDR hPPR feature

1. Add CXL command support to set/get enable/disable DDR PPR request
2. Add CXL command support to get/set DDR hPPR address info
3. Add CXL command support to clear DDR hPPR address info per DIMM
4. Add CXL command support to query DDR PPR state needed for handshake


Use following CXL commands to test DDR hPPR feature (after flashing using QSPI bootflow.sh)

Following CXL client changes are needed for validation (https://github.com/facebookexperimental/ndctl/pull/33)

__**Command Help**__

**Command to get current DDR hPPR info**
```
./cxl/cxl ddr-hppr-get

 usage: cxl ddr-hppr-get <mem0> [<mem1>..<memN>] [<options>]

    -v, --verbose         turn on debug
```
**Command to set the DDR hPPR**
```
 ./cxl/cxl ddr-hppr-set

 usage: cxl ddr-hppr-set <<mem0> [<mem1>..<memN>] [<options>]

    -v, --verbose         turn on debug
    -e, --ddr_hppr_en <n>
                          HPPR Enable/Disable value(1/0)
```

**Command to get the DDR hPPR address info**
```
./cxl/cxl ddr-hppr-addr-info-get

 usage: cxl ddr-hppr-addr-info-get <mem0> [<mem1>..<memN>] [<options>]

    -v, --verbose         turn on debug
```
**Command to set the DDR hPPR address info**
```
./cxl/cxl ddr-hppr-addr-info-set

 usage: cxl ddr-hppr-addr-info-set <<mem0> [<mem1>..<memN>] [<options>]

    -v, --verbose         turn on debug
    -d, --ddr_id <n>      HPPR addr info: DDR controller ID value
    -c, --chip_select <n>
                          HPPR addr info: chip select value
    -g, --bank_group <n>  HPPR addr info: bank group value
    -b, --bank <n>        HPPR addr info: bank value
    -r, --row <n>         HPPR addr info: row value
```
**Command to clear the DDR hPPR address info for a given DIMM (DDR_ID+Channel_ID)**
```
./cxl/cxl ddr-hppr-addr-info-clear

 usage: cxl ddr-hppr-addr-info-clear <<mem0> [<mem1>..<memN>] [<options>]

    -v, --verbose         turn on debug
    -d, --ddr_id <n>      HPPR addr info: DDR controller ID value
    -c, --channel_id <n>  HPPR addr info: channel ID value
```
**Command to query the status of DDR PPR request (completed or not enabled)**
```
./cxl/cxl ddr-ppr-status-get

 usage: cxl ddr-ppr-status-get <mem0> [<mem1>..<memN>] [<options>]

    -v, --verbose         turn on debug
```


__**Steps to trigger DDR hPPR**__
1. Set the hPPR 
`./cxl/cxl ddr-hppr-set mem0 -e 1`
2. Get the hPPR  
` ./cxl/cxl ddr-hppr-get mem0`
`DDR[0] HPPR is Enabled`
`DDR[1] HPPR is Enabled`
3. Set the required hPPR address info, say for DDR0 channel 0 and 1
`./cxl/cxl ddr-hppr-addr-info-set mem0 -d 0  -c 1  -g 0  -b 0 -r 0`
`./cxl/cxl ddr-hppr-addr-info-set mem0 -d 0  -c 1 -g 1 -b 1 -r 1`
`./cxl/cxl ddr-hppr-addr-info-set mem0 -d 0  -c 0 -g 2 -b 2 -r 2`
`./cxl/cxl ddr-hppr-addr-info-set mem0 -d 0  -c 0 -g 3 -b 3 -r 3`
`./cxl/cxl ddr-hppr-addr-info-set mem0 -d 0 -c 2 -g 0  -b 0 -r 0`
`./cxl/cxl ddr-hppr-addr-info-set mem0 -d 0 -c 2 -g 1 -b 1 -r 1`
`./cxl/cxl ddr-hppr-addr-info-set mem0 -d 0 -c 2 -g 2 -b 2 -r 2`
` ./cxl/cxl ddr-hppr-addr-info-set mem0 -d 0 -c 2 -g 3 -b 3 -r 3`
4. Get the hPPR address info (to verify if all address info is set properly)
`./cxl/cxl ddr-hppr-addr-info-get mem0`
`DDR[0],id[0],ch=0,cs=1,bg=0x00,b=0x00,r=0x00000000,ppr_state=1
DDR[0],id[1],ch=0,cs=1,bg=0x01,b=0x01,r=0x00000001,ppr_state=1
DDR[0],id[2],ch=0,cs=0,bg=0x02,b=0x02,r=0x00000002,ppr_state=1
DDR[0],id[3],ch=0,cs=0,bg=0x03,b=0x03,r=0x00000003,ppr_state=1
DDR[0],id[4],ch=1,cs=2,bg=0x00,b=0x00,r=0x00000000,ppr_state=1
DDR[0],id[5],ch=1,cs=2,bg=0x01,b=0x01,r=0x00000001,ppr_state=1
DDR[0],id[6],ch=1,cs=2,bg=0x02,b=0x02,r=0x00000002,ppr_state=1
DDR[0],id[7],ch=1,cs=2,bg=0x03,b=0x03,r=0x00000003,ppr_state=1
DDR[1],id[0],ch=0,cs=0,bg=0x00,b=0x00,r=0x00000000,ppr_state=0
DDR[1],id[1],ch=0,cs=0,bg=0x00,b=0x00,r=0x00000000,ppr_state=0
DDR[1],id[2],ch=0,cs=0,bg=0x00,b=0x00,r=0x00000000,ppr_state=0
DDR[1],id[3],ch=0,cs=0,bg=0x00,b=0x00,r=0x00000000,ppr_state=0
DDR[1],id[4],ch=0,cs=0,bg=0x00,b=0x00,r=0x00000000,ppr_state=0
DDR[1],id[5],ch=0,cs=0,bg=0x00,b=0x00,r=0x00000000,ppr_state=0
DDR[1],id[6],ch=0,cs=0,bg=0x00,b=0x00,r=0x00000000,ppr_state=0
DDR[1],id[7],ch=0,cs=0,bg=0x00,b=0x00,r=0x00000000,ppr_state=0`

5. Query the PPR status (expected value: 1(PPR NOT ENABLED))
` ./cxl/cxl ddr-ppr-status-get mem1`
`DDR PPR Status is 1`
6. Reboot the host using DC/AC cycle
7. Vistara executes PPR only for the given DDR controller and bank_groups
8. Query the PPR status (expected value: 2(PPR COMPLETED))
` ./cxl/cxl ddr-ppr-status-get mem1`
`DDR PPR Status is 2`
9. We can check the hPPR address info, ppr_state is updated to ppr_done(2)
`./cxl/cxl ddr-hppr-addr-info-get mem0`
`DDR[0],id[0],ch=0,cs=1,bg=0x00,b=0x00,r=0x00000000,ppr_state=2 DDR[0],id[1],ch=0,cs=1,bg=0x01,b=0x01,r=0x00000001,ppr_state=2 DDR[0],id[2],ch=0,cs=0,bg=0x02,b=0x02,r=0x00000002,ppr_state=2 DDR[0],id[3],ch=0,cs=0,bg=0x03,b=0x03,r=0x00000003,ppr_state=2 DDR[0],id[4],ch=1,cs=2,bg=0x00,b=0x00,r=0x00000000,ppr_state=2 DDR[0],id[5],ch=1,cs=2,bg=0x01,b=0x01,r=0x00000001,ppr_state=2 DDR[0],id[6],ch=1,cs=2,bg=0x02,b=0x02,r=0x00000002,ppr_state=2 DDR[0],id[7],ch=1,cs=2,bg=0x03,b=0x03,r=0x00000003,ppr_state=2 DDR[1],id[0],ch=0,cs=0,bg=0x00,b=0x00,r=0x00000000,ppr_state=0 DDR[1],id[1],ch=0,cs=0,bg=0x00,b=0x00,r=0x00000000,ppr_state=0 DDR[1],id[2],ch=0,cs=0,bg=0x00,b=0x00,r=0x00000000,ppr_state=0 DDR[1],id[3],ch=0,cs=0,bg=0x00,b=0x00,r=0x00000000,ppr_state=0 DDR[1],id[4],ch=0,cs=0,bg=0x00,b=0x00,r=0x00000000,ppr_state=0 DDR[1],id[5],ch=0,cs=0,bg=0x00,b=0x00,r=0x00000000,ppr_state=0 DDR[1],id[6],ch=0,cs=0,bg=0x00,b=0x00,r=0x00000000,ppr_state=0 DDR[1],id[7],ch=0,cs=0,bg=0x00,b=0x00,r=0x00000000,ppr_state=0`
10. Once PPR completed, Reboot the host using DC cycle

__**Steps to trigger clear hPPR address info in faulty DIMMS are replaced**__
1. Get the hPPR address info (to verify if all address info is set properly)
`./cxl/cxl ddr-hppr-addr-info-get mem0`
`DDR[0],id[0],ch=0,cs=1,bg=0x00,b=0x00,r=0x00000000,ppr_state=2 DDR[0],id[1],ch=0,cs=1,bg=0x01,b=0x01,r=0x00000001,ppr_state=2 DDR[0],id[2],ch=0,cs=0,bg=0x02,b=0x02,r=0x00000002,ppr_state=2 DDR[0],id[3],ch=0,cs=0,bg=0x03,b=0x03,r=0x00000003,ppr_state=2 DDR[0],id[4],ch=1,cs=2,bg=0x00,b=0x00,r=0x00000000,ppr_state=2 DDR[0],id[5],ch=1,cs=2,bg=0x01,b=0x01,r=0x00000001,ppr_state=2 DDR[0],id[6],ch=1,cs=2,bg=0x02,b=0x02,r=0x00000002,ppr_state=2 DDR[0],id[7],ch=1,cs=2,bg=0x03,b=0x03,r=0x00000003,ppr_state=2 DDR[1],id[0],ch=0,cs=0,bg=0x00,b=0x00,r=0x00000000,ppr_state=0 DDR[1],id[1],ch=0,cs=0,bg=0x00,b=0x00,r=0x00000000,ppr_state=0 DDR[1],id[2],ch=0,cs=0,bg=0x00,b=0x00,r=0x00000000,ppr_state=0 DDR[1],id[3],ch=0,cs=0,bg=0x00,b=0x00,r=0x00000000,ppr_state=0 DDR[1],id[4],ch=0,cs=0,bg=0x00,b=0x00,r=0x00000000,ppr_state=0 DDR[1],id[5],ch=0,cs=0,bg=0x00,b=0x00,r=0x00000000,ppr_state=0 DDR[1],id[6],ch=0,cs=0,bg=0x00,b=0x00,r=0x00000000,ppr_state=0 DDR[1],id[7],ch=0,cs=0,bg=0x00,b=0x00,r=0x00000000,ppr_state=0`
2. Clear the required hPPR address info, say for DDR0 channel 0
`./cxl/cxl ddr-hppr-addr-info-clear mem0 -d 0 -c 0`
3. Get the hPPR address info (to verify)
`./cxl/cxl ddr-hppr-addr-info-get mem0`
`DDR[0],id[0],ch=0,cs=0,bg=0x00,b=0x00,r=0x00000000,ppr_state=0
DDR[0],id[1],ch=0,cs=0,bg=0x00,b=0x00,r=0x00000000,ppr_state=0
DDR[0],id[2],ch=0,cs=0,bg=0x00,b=0x00,r=0x00000000,ppr_state=0
DDR[0],id[3],ch=0,cs=0,bg=0x00,b=0x00,r=0x00000000,ppr_state=0
DDR[0],id[4],ch=1,cs=2,bg=0x00,b=0x00,r=0x00000000,ppr_state=2
DDR[0],id[5],ch=1,cs=2,bg=0x01,b=0x01,r=0x00000001,ppr_state=2
DDR[0],id[6],ch=1,cs=2,bg=0x02,b=0x02,r=0x00000002,ppr_state=2
DDR[0],id[7],ch=1,cs=2,bg=0x03,b=0x03,r=0x00000003,ppr_state=2
DDR[1],id[0],ch=0,cs=0,bg=0x00,b=0x00,r=0x00000000,ppr_state=0
DDR[1],id[1],ch=0,cs=0,bg=0x00,b=0x00,r=0x00000000,ppr_state=0
DDR[1],id[2],ch=0,cs=0,bg=0x00,b=0x00,r=0x00000000,ppr_state=0
DDR[1],id[3],ch=0,cs=0,bg=0x00,b=0x00,r=0x00000000,ppr_state=0
DDR[1],id[4],ch=0,cs=0,bg=0x00,b=0x00,r=0x00000000,ppr_state=0
DDR[1],id[5],ch=0,cs=0,bg=0x00,b=0x00,r=0x00000000,ppr_state=0
DDR[1],id[6],ch=0,cs=0,bg=0x00,b=0x00,r=0x00000000,ppr_state=0
DDR[1],id[7],ch=0,cs=0,bg=0x00,b=0x00,r=0x00000000,ppr_state=0`