### PR TITLE
Counting CXL errors for Correctable, Uncorrectable, and CFG err type

### DIFF
--- a/cxl/builtin.h
+++ b/cxl/builtin.h
@@ -164,4 +164,5 @@ int cmd_ddr_hppr_addr_info_clear(int argc, const char **argv, struct cxl_ctx *ct
 int cmd_ddr_ppr_status_get(int argc, const char **argv, struct cxl_ctx *ctx);
 int cmd_ddr_refresh_mode_set(int argc, const char **argv, struct cxl_ctx *ctx);
 int cmd_ddr_refresh_mode_get(int argc, const char **argv, struct cxl_ctx *ctx);
+int cmd_cxl_err_cnt_get(int argc, const char **argv, struct cxl_ctx *ctx);
 #endif /* _CXL_BUILTIN_H_ */

--- a/cxl/cxl.c
+++ b/cxl/cxl.c
@@ -220,6 +220,7 @@ static struct cmd_struct commands[] = {
 	{ "ddr-ppr-status-get", .c_fn = cmd_ddr_ppr_status_get },
 	{ "ddr-refresh-mode-set", .c_fn = cmd_ddr_refresh_mode_set },
 	{ "ddr-refresh-mode-get", .c_fn = cmd_ddr_refresh_mode_get },
+	{ "cxl-err-cnt-get", .c_fn = cmd_cxl_err_cnt_get },
 };
 
 int main(int argc, const char **argv)

--- a/cxl/lib/libcxl.sym
+++ b/cxl/lib/libcxl.sym
@@ -221,4 +221,5 @@ global:
     cxl_memdev_ddr_ppr_status_get;
     cxl_memdev_ddr_refresh_mode_set;
     cxl_memdev_ddr_refresh_mode_get;
+    cxl_memdev_cxl_err_cnt_get;
 } LIBCXL_3;

--- a/cxl/libcxl.h
+++ b/cxl/libcxl.h
@@ -290,6 +290,7 @@ int cxl_memdev_ddr_hppr_addr_info_clear(struct cxl_memdev *memdev, u8 ddr_id, u8
 int cxl_memdev_ddr_ppr_status_get(struct cxl_memdev *memdev);
 int cxl_memdev_ddr_refresh_mode_set(struct cxl_memdev *memdev, u8 refresh_select_option);
 int cxl_memdev_ddr_refresh_mode_get(struct cxl_memdev *memdev);
+int cxl_memdev_cxl_err_cnt_get(struct cxl_memdev *memdev);
 
 #define cxl_memdev_foreach(ctx, memdev) \
         for (memdev = cxl_memdev_get_first(ctx); \

--- a/cxl/memdev.c
+++ b/cxl/memdev.c
@@ -2423,6 +2423,11 @@ static const struct option cmd_ddr_refresh_mode_select_get_options[] = {
   OPT_END(),
 };
 
+static const struct option cmd_cxl_err_cnt_get_options[] = {
+    BASE_OPTIONS(),
+    OPT_END(),
+};
+
 static int action_cmd_clear_event_records(struct cxl_memdev *memdev, struct action_context *actx)
 {
   u16 record_handle;
@@ -6086,4 +6091,26 @@ int cmd_ddr_refresh_mode_get(int argc, const char **argv, struct cxl_ctx *ctx)
       "cxl ddr-refresh-mode-get <mem0> [<mem1>..<memN>] [<options>]");
 
   return rc >= 0 ? 0 : EXIT_FAILURE;
+}
+
+static int action_cmd_cxl_err_cnt_get(struct cxl_memdev *memdev,
+                      struct action_context *actx)
+{
+    if (cxl_memdev_is_active(memdev)) {
+        fprintf(stderr, "%s: memdev active, cxl get Error count \n",
+            cxl_memdev_get_devname(memdev));
+        return -EBUSY;
+    }
+
+    return cxl_memdev_cxl_err_cnt_get(memdev);
+}
+
+int cmd_cxl_err_cnt_get(int argc, const char **argv, struct cxl_ctx *ctx)
+{
+    int rc = memdev_action(
+        argc, argv, ctx, action_cmd_cxl_err_cnt_get,
+        cmd_cxl_err_cnt_get_options,
+        "cxl cxl-err-cnt-get <mem0> [<mem1>..<memN>] [<options>]");
+
+    return rc >= 0 ? 0 : EXIT_FAILURE;
 }


### PR DESCRIPTION
Summary:  VISTARTA: Counting CXL errors for Correctable, Uncorrectable, and CFG err type

Test Plan: 1) Inject errors by cxl pci-err-inj
                2) get the logs on Uart terminal to confirm if the error is injected
                3) uart shell command to get the count update [ cxl list_errors]
               4) execute implemented cxl command cxl-err-cnt-get to get the same out put on cxl terminal

Reviewers:

Subscribers:

Tasks: T191983816 : implement cxl error counters on device side

Tags: