### PR TITLE
VISTARA: Added Support for ddr frequency mailbox command

### DIFF
--- a/cxl/builtin.h
+++ b/cxl/builtin.h
@@ -165,4 +165,5 @@ int cmd_ddr_ppr_status_get(int argc, const char **argv, struct cxl_ctx *ctx);
 int cmd_ddr_refresh_mode_set(int argc, const char **argv, struct cxl_ctx *ctx);
 int cmd_ddr_refresh_mode_get(int argc, const char **argv, struct cxl_ctx *ctx);
 int cmd_cxl_err_cnt_get(int argc, const char **argv, struct cxl_ctx *ctx);
+int cmd_ddr_freq_get(int argc, const char **argv, struct cxl_ctx *ctx);
 #endif /* _CXL_BUILTIN_H_ */

--- a/cxl/cxl.c
+++ b/cxl/cxl.c
@@ -221,6 +221,7 @@ static struct cmd_struct commands[] = {
 	{ "ddr-refresh-mode-set", .c_fn = cmd_ddr_refresh_mode_set },
 	{ "ddr-refresh-mode-get", .c_fn = cmd_ddr_refresh_mode_get },
 	{ "cxl-err-cnt-get", .c_fn = cmd_cxl_err_cnt_get },
+	{ "ddr-freq-get", .c_fn = cmd_ddr_freq_get },
 };
 
 int main(int argc, const char **argv)

--- a/cxl/lib/libcxl.c
+++ b/cxl/lib/libcxl.c
@@ -15327,3 +15327,72 @@ out:
     cxl_cmd_unref(cmd);
     return rc;
 }
+
+/* DDR OPERATING FREQUENCY GET */
+#define CXL_MEM_COMMAND_ID_CXL_DDR_FREQ_GET CXL_MEM_COMMAND_ID_RAW
+#define CXL_MEM_COMMAND_ID_CXL_DDR_FREQ_GET_OPCODE 0xFB35
+
+struct ddr_operating_freq {
+  float ddr_freq;
+} __attribute__((packed)) ddr_frequency;
+
+struct cxl_mbox_handle_ddr_frequency_select_out {
+  struct ddr_operating_freq ddr_frequency;
+} __attribute__((packed));
+
+CXL_EXPORT int cxl_memdev_ddr_freq_get(struct cxl_memdev *memdev)
+{
+    struct cxl_cmd *cmd;
+    struct cxl_mem_query_commands *query;
+    struct cxl_command_info *cinfo;
+    struct  cxl_mbox_handle_ddr_frequency_select_out *handle_frequency_selection_out;
+    int rc = 0;
+
+    cmd = cxl_cmd_new_raw(memdev, CXL_MEM_COMMAND_ID_CXL_DDR_FREQ_GET_OPCODE);
+    if (!cmd) {
+        fprintf(stderr, "%s: cxl_cmd_new_raw returned Null output\n",
+                cxl_memdev_get_devname(memdev));
+        return -ENOMEM;
+    }
+
+    query = cmd->query_cmd;
+    cinfo = &query->commands[cmd->query_idx];
+
+    /* used to force correct payload size */
+    cinfo->size_in = 0; //CXL_MEM_COMMAND_ID_LOG_INFO_PAYLOAD_IN_SIZE;
+    if (cinfo->size_in > 0) {
+        cmd->input_payload = calloc(1, cinfo->size_in);
+        if (!cmd->input_payload)
+            return -ENOMEM;
+        cmd->send_cmd->in.payload = (u64)cmd->input_payload;
+        cmd->send_cmd->in.size = cinfo->size_in;
+    }
+
+    rc = cxl_cmd_submit(cmd);
+    if (rc < 0) {
+        fprintf(stderr, "%s: cmd submission failed: %d (%s)\n",
+                cxl_memdev_get_devname(memdev), rc, strerror(-rc));
+        goto out;
+    }
+
+    rc = cxl_cmd_get_mbox_status(cmd);
+    if (rc != 0) {
+        fprintf(stderr, "%s: firmware status: %d\n",
+                cxl_memdev_get_devname(memdev), rc);
+        goto out;
+    }
+
+    if (cmd->send_cmd->id != CXL_MEM_COMMAND_ID_CXL_DDR_FREQ_GET) {
+        fprintf(stderr, "%s: invalid command id 0x%x (expecting 0x%x)\n",
+                cxl_memdev_get_devname(memdev), cmd->send_cmd->id,
+                CXL_MEM_COMMAND_ID_CXL_DDR_FREQ_GET);
+        return -EINVAL;
+    }
+
+    handle_frequency_selection_out = (struct cxl_mbox_handle_ddr_frequency_select_out *)cmd->send_cmd->out.payload;
+    fprintf(stdout, "DDR Operating Frequency: %f MHz\n", handle_frequency_selection_out->ddr_frequency.ddr_freq);
+
+out:
+    cxl_cmd_unref(cmd);
+    return rc;
+}

--- a/cxl/lib/libcxl.sym
+++ b/cxl/lib/libcxl.sym
@@ -222,4 +222,5 @@ global:
     cxl_memdev_ddr_refresh_mode_set;
     cxl_memdev_ddr_refresh_mode_get;
     cxl_memdev_cxl_err_cnt_get;
+    cxl_memdev_ddr_freq_get;
 } LIBCXL_3;

--- a/cxl/libcxl.h
+++ b/cxl/libcxl.h
@@ -291,6 +291,7 @@ int cxl_memdev_ddr_ppr_status_get(struct cxl_memdev *memdev);
 int cxl_memdev_ddr_refresh_mode_set(struct cxl_memdev *memdev, u8 refresh_select_option);
 int cxl_memdev_ddr_refresh_mode_get(struct cxl_memdev *memdev);
 int cxl_memdev_cxl_err_cnt_get(struct cxl_memdev *memdev);
+int cxl_memdev_ddr_freq_get(struct cxl_memdev *memdev);
 
 #define cxl_memdev_foreach(ctx, memdev) \
         for (memdev = cxl_memdev_get_first(ctx); \

--- a/cxl/memdev.c
+++ b/cxl/memdev.c
@@ -2428,6 +2428,11 @@ static const struct option cmd_cxl_err_cnt_get_options[] = {
     OPT_END(),
 };
 
+static const struct option cmd_ddr_frequency_select_get_options[] = {
+  BASE_OPTIONS(),
+  OPT_END(),
+};
+
 static int action_cmd_clear_event_records(struct cxl_memdev *memdev, struct action_context *actx)
 {
   u16 record_handle;
@@ -4645,6 +4650,18 @@ static int action_cmd_ddr_refresh_mode_get(struct cxl_memdev *memdev,
 	return cxl_memdev_ddr_refresh_mode_get(memdev);
 }
 
+static int action_cmd_ddr_frequency_get(struct cxl_memdev *memdev,
+                                      struct action_context *actx)
+{
+	if (cxl_memdev_is_active(memdev)) {
+		fprintf(stderr, "%s: memdev active, abort ddr_refresh_mode_get\n",
+			cxl_memdev_get_devname(memdev));
+		return -EBUSY;
+	}
+
+	return cxl_memdev_ddr_freq_get(memdev);
+}
+
 static int action_write(struct cxl_memdev *memdev, struct action_context *actx)
 {
   size_t size = param.len, read_len;
@@ -6113,4 +6130,12 @@ int cmd_cxl_err_cnt_get(int argc, const char **argv, struct cxl_ctx *ctx)
         "cxl cxl-err-cnt-get <mem0> [<mem1>..<memN>] [<options>]");
 
     return rc >= 0 ? 0 : EXIT_FAILURE;
+}
+
+int cmd_ddr_freq_get(int argc, const char **argv, struct cxl_ctx *ctx)
+{
+  int rc = memdev_action(argc, argv, ctx, action_cmd_ddr_frequency_get, cmd_ddr_frequency_select_get_options,
+      "cxl ddr-freq-get <mem0> [<mem1>..<memN>] [<options>]");
+
+  return rc >= 0 ? 0 : EXIT_FAILURE;
 }


### PR DESCRIPTION
Summary:

-Add support for ddr-freq- get command
-This allows the system to process requests for DDR operating frequency.

Test Plan:
- From ndctl command perform the below steps [root@dhcp-100-97-47-177 cxl]# ./cxl ddr-freq-get usage: cxl ddr-freq-get <mem0> [<mem1>..<memN>] [<options>]
  -v, --verbose         turn on debug
  [root@dhcp-100-97-47-177 cxl]# ./cxl ddr-freq-get mem0
  DDR Operating Frequency: 2390.631104 MHz
  [root@dhcp-100-97-47-177 cxl]# ./cxl ddr-freq-get mem1
  DDR Operating Frequency: 2390.631104 MHz
- Device should get the frequency through the mailbox command
Reviewers:

Subscribers: @sandeepa-prabhu-meta  @lnishal 

Tasks:

Tags: