### PR TITLE
VISTARA : Add counters for ddr errors

### DIFF
--- a/cxl/builtin.h
+++ b/cxl/builtin.h
@@ -166,4 +166,5 @@ int cmd_ddr_refresh_mode_set(int argc, const char **argv, struct cxl_ctx *ctx);
 int cmd_ddr_refresh_mode_get(int argc, const char **argv, struct cxl_ctx *ctx);
 int cmd_cxl_err_cnt_get(int argc, const char **argv, struct cxl_ctx *ctx);
 int cmd_ddr_freq_get(int argc, const char **argv, struct cxl_ctx *ctx);
+int cmd_cxl_ddr_bist_err_info_get(int argc, const char **argv, struct cxl_ctx *ctx);
 #endif /* _CXL_BUILTIN_H_ */

--- a/cxl/cxl.c
+++ b/cxl/cxl.c
@@ -222,6 +222,7 @@ static struct cmd_struct commands[] = {
 	{ "ddr-refresh-mode-get", .c_fn = cmd_ddr_refresh_mode_get },
 	{ "cxl-err-cnt-get", .c_fn = cmd_cxl_err_cnt_get },
 	{ "ddr-freq-get", .c_fn = cmd_ddr_freq_get },
+	{ "ddr-err-bist-info-get", .c_fn = cmd_cxl_ddr_bist_err_info_get },
 };
 
 int main(int argc, const char **argv)

--- a/cxl/lib/libcxl.sym
+++ b/cxl/lib/libcxl.sym
@@ -223,4 +223,5 @@ global:
     cxl_memdev_ddr_refresh_mode_get;
     cxl_memdev_cxl_err_cnt_get;
     cxl_memdev_ddr_freq_get;
+    cxl_memdev_ddr_init_err_info_get;
 } LIBCXL_3;

--- a/cxl/libcxl.h
+++ b/cxl/libcxl.h
@@ -292,6 +292,7 @@ int cxl_memdev_ddr_refresh_mode_set(struct cxl_memdev *memdev, u8 refresh_select
 int cxl_memdev_ddr_refresh_mode_get(struct cxl_memdev *memdev);
 int cxl_memdev_cxl_err_cnt_get(struct cxl_memdev *memdev);
 int cxl_memdev_ddr_freq_get(struct cxl_memdev *memdev);
+int cxl_memdev_ddr_init_err_info_get(struct cxl_memdev *memdev);
 
 #define cxl_memdev_foreach(ctx, memdev) \
         for (memdev = cxl_memdev_get_first(ctx); \

--- a/cxl/memdev.c
+++ b/cxl/memdev.c
@@ -2433,6 +2433,11 @@ static const struct option cmd_ddr_frequency_select_get_options[] = {
   OPT_END(),
 };
 
+static const struct option cmd_cxl_ddr_bist_err_info_get_options[] = {
+  BASE_OPTIONS(),
+  OPT_END(),
+};
+
 static int action_cmd_clear_event_records(struct cxl_memdev *memdev, struct action_context *actx)
 {
   u16 record_handle;
@@ -6138,4 +6143,26 @@ int cmd_ddr_freq_get(int argc, const char **argv, struct cxl_ctx *ctx)
       "cxl ddr-freq-get <mem0> [<mem1>..<memN>] [<options>]");
 
   return rc >= 0 ? 0 : EXIT_FAILURE;
+}
+
+static int action_cmd_cxl_ddr_bist_err_info_get(struct cxl_memdev *memdev,
+                      struct action_context *actx)
+{
+    if (cxl_memdev_is_active(memdev)) {
+        fprintf(stderr, "%s: memdev active, cxl get Error count \n",
+            cxl_memdev_get_devname(memdev));
+        return -EBUSY;
+    }
+
+    return cxl_memdev_ddr_init_err_info_get(memdev);
+}
+
+int cmd_cxl_ddr_bist_err_info_get(int argc, const char **argv, struct cxl_ctx *ctx)
+{
+    int rc = memdev_action(
+        argc, argv, ctx, action_cmd_cxl_ddr_bist_err_info_get,
+        cmd_cxl_ddr_bist_err_info_get_options,
+        "cxl cxl-ddr-bist-err-info-get <mem0> [<mem1>..<memN>] [<options>]");
+
+    return rc >= 0 ? 0 : EXIT_FAILURE;
 }


### PR DESCRIPTION
**Summary :** This is to  create 1 vendor specific command about collecting error information for DDR BIST error

**Description:**  
- If there is any BIST error generated during boot / run then firmware will capture all the details (count, row, col, cs and bank) about the same and store it in NVdata field. 
- After reboot this info will be persistent and hence would be useful for further debugging. 
- Ndctl has implemented command " CXL_MEM_COMMAND_ID_CXL_DDR_INIT_ERR_INFO_GET_OPCODE  :: 0xFB36" to provide that error details from NVdata to the user.

**OutPut :**
cxl ddr-err-bist-info-get mem0
BIST error details for DDR (0) 
DDR BIST error count 34
DDR BIST error info (col)0
DDR BIST error info (row)0
DDR BIST error info (bank)0
DDR BIST error info (cs)0
BIST error details for DDR (1) 
DDR BIST error count 0
DDR BIST error info (col)0
DDR BIST error info (row)0
DDR BIST error info (bank)0
DDR BIST error info (cs)0

**Tasks:** T202989303
