### PR TITLE
VISTARTA : Implement DDR BIST ERROR INFO CLEAR command

### DIFF
--- a/cxl/builtin.h
+++ b/cxl/builtin.h
@@ -167,4 +167,5 @@ int cmd_ddr_refresh_mode_get(int argc, const char **argv, struct cxl_ctx *ctx);
 int cmd_cxl_err_cnt_get(int argc, const char **argv, struct cxl_ctx *ctx);
 int cmd_ddr_freq_get(int argc, const char **argv, struct cxl_ctx *ctx);
 int cmd_cxl_ddr_bist_err_info_get(int argc, const char **argv, struct cxl_ctx *ctx);
+int cmd_cxl_ddr_bist_err_info_clr(int argc, const char **argv, struct cxl_ctx *ctx);
 #endif /* _CXL_BUILTIN_H_ */

--- a/cxl/cxl.c
+++ b/cxl/cxl.c
@@ -223,6 +223,7 @@ static struct cmd_struct commands[] = {
 	{ "cxl-err-cnt-get", .c_fn = cmd_cxl_err_cnt_get },
 	{ "ddr-freq-get", .c_fn = cmd_ddr_freq_get },
 	{ "ddr-err-bist-info-get", .c_fn = cmd_cxl_ddr_bist_err_info_get },
+	{ "ddr-err-bist-info-clr", .c_fn = cmd_cxl_ddr_bist_err_info_clr },
 };
 
 int main(int argc, const char **argv)

--- a/cxl/lib/libcxl.sym
+++ b/cxl/lib/libcxl.sym
@@ -224,4 +224,5 @@ global:
     cxl_memdev_cxl_err_cnt_get;
     cxl_memdev_ddr_freq_get;
     cxl_memdev_ddr_init_err_info_get;
+    cxl_memdev_ddr_bist_err_info_clr;
 } LIBCXL_3;

--- a/cxl/libcxl.h
+++ b/cxl/libcxl.h
@@ -293,6 +293,7 @@ int cxl_memdev_ddr_refresh_mode_get(struct cxl_memdev *memdev);
 int cxl_memdev_cxl_err_cnt_get(struct cxl_memdev *memdev);
 int cxl_memdev_ddr_freq_get(struct cxl_memdev *memdev);
 int cxl_memdev_ddr_init_err_info_get(struct cxl_memdev *memdev);
+int cxl_memdev_ddr_bist_err_info_clr(struct cxl_memdev *memdev);
 
 #define cxl_memdev_foreach(ctx, memdev) \
         for (memdev = cxl_memdev_get_first(ctx); \

--- a/cxl/memdev.c
+++ b/cxl/memdev.c
@@ -2438,6 +2438,11 @@ static const struct option cmd_cxl_ddr_bist_err_info_get_options[] = {
   OPT_END(),
 };
 
+static const struct option cmd_cxl_ddr_bist_err_info_clr_options[] = {
+  BASE_OPTIONS(),
+  OPT_END(),
+};
+
 static int action_cmd_clear_event_records(struct cxl_memdev *memdev, struct action_context *actx)
 {
   u16 record_handle;
@@ -6149,12 +6154,24 @@ static int action_cmd_cxl_ddr_bist_err_info_get(struct cxl_memdev *memdev,
                       struct action_context *actx)
 {
     if (cxl_memdev_is_active(memdev)) {
-        fprintf(stderr, "%s: memdev active, cxl get Error count \n",
+        fprintf(stderr, "%s: memdev active, cxl get error count \n",
             cxl_memdev_get_devname(memdev));
         return -EBUSY;
     }
 
     return cxl_memdev_ddr_init_err_info_get(memdev);
+}
+
+static int action_cmd_cxl_ddr_bist_err_info_clr(struct cxl_memdev *memdev,
+                      struct action_context *actx)
+{
+    if (cxl_memdev_is_active(memdev)) {
+        fprintf(stderr, "%s: memdev active, clear cxl bist error info \n",
+            cxl_memdev_get_devname(memdev));
+        return -EBUSY;
+    }
+
+    return cxl_memdev_ddr_bist_err_info_clr(memdev);
 }
 
 int cmd_cxl_ddr_bist_err_info_get(int argc, const char **argv, struct cxl_ctx *ctx)
@@ -6163,6 +6180,16 @@ int cmd_cxl_ddr_bist_err_info_get(int argc, const char **argv, struct cxl_ctx *c
         argc, argv, ctx, action_cmd_cxl_ddr_bist_err_info_get,
         cmd_cxl_ddr_bist_err_info_get_options,
         "cxl cxl-ddr-bist-err-info-get <mem0> [<mem1>..<memN>] [<options>]");
+
+    return rc >= 0 ? 0 : EXIT_FAILURE;
+}
+
+int cmd_cxl_ddr_bist_err_info_clr(int argc, const char **argv, struct cxl_ctx *ctx)
+{
+    int rc = memdev_action(
+        argc, argv, ctx, action_cmd_cxl_ddr_bist_err_info_clr,
+        cmd_cxl_ddr_bist_err_info_clr_options,
+        "cxl cxl-ddr-bist-err-info-clr <mem0> [<mem1>..<memN>] [<options>]");
 
     return rc >= 0 ? 0 : EXIT_FAILURE;
 }


### PR DESCRIPTION
Summary:
This is in the sync. with diff D69175829.
Implementing mailbox command to clear DDR BIST error info. This implementation is requested because BIST error info is persistent and it obviously won't change on its own even if DIMMs are changed. And hence in Next reboot it would be showing BIST ERROR info for the newly added DIMMs which would be misleading. Hence this mailBox command is implemented, which will allow user to clear the BIST error info in such scenarios. And it would be user's responsibility to clear BIST error info who would install new DIMMs.

Test Plan:
To create a forced BIST error scenario, modify the cxl FW code and then get the details using

step 1) [root@DG18161 cxl]# ./cxl ddr-err-bist-info-get mem0
                         This will show some counter value, column, row, bank details in this case
step 2)  [root@DG18161 cxl]# ./cxl ddr-err-bist-info-clr mem0
                          This will reset all values to ZEROs in nvdata as well.
Step 3)  Repeat step 1 and check if the value is ZERO step 4)  Reboot HOST
step 5)  Check Step 1.

Reviewers:

Subscribers:

Tasks:

Tags: