### PR TITLE
VISTARA : Adding counter for DDR SPD error (NDCTL code changes)

### DIFF
--- a/cxl/builtin.h
+++ b/cxl/builtin.h
@@ -168,4 +168,6 @@ int cmd_cxl_err_cnt_get(int argc, const char **argv, struct cxl_ctx *ctx);
 int cmd_ddr_freq_get(int argc, const char **argv, struct cxl_ctx *ctx);
 int cmd_cxl_ddr_bist_err_info_get(int argc, const char **argv, struct cxl_ctx *ctx);
 int cmd_cxl_ddr_bist_err_info_clr(int argc, const char **argv, struct cxl_ctx *ctx);
+int cmd_cxl_ddr_spd_err_info_get(int argc, const char **argv, struct cxl_ctx *ctx);
+int cmd_cxl_ddr_spd_err_info_clr(int argc, const char **argv, struct cxl_ctx *ctx);
 #endif /* _CXL_BUILTIN_H_ */

--- a/cxl/cxl.c
+++ b/cxl/cxl.c
@@ -224,6 +224,8 @@ static struct cmd_struct commands[] = {
 	{ "ddr-freq-get", .c_fn = cmd_ddr_freq_get },
 	{ "ddr-err-bist-info-get", .c_fn = cmd_cxl_ddr_bist_err_info_get },
 	{ "ddr-err-bist-info-clr", .c_fn = cmd_cxl_ddr_bist_err_info_clr },
+	{ "ddr-err-spd-info-get", .c_fn = cmd_cxl_ddr_spd_err_info_get },
+	{ "ddr-err-spd-info-clr", .c_fn = cmd_cxl_ddr_spd_err_info_clr },
 };
 
 int main(int argc, const char **argv)

--- a/cxl/lib/libcxl.c
+++ b/cxl/lib/libcxl.c
@@ -15543,3 +15543,148 @@ out:
     cxl_cmd_unref(cmd);
     return rc;
 }
+
+/* DDR SPD ERROR INFO GET */
+#define CXL_MEM_COMMAND_ID_CXL_DDR_SPD_ERR_INFO_GET CXL_MEM_COMMAND_ID_RAW
+#define CXL_MEM_COMMAND_ID_CXL_DDR_SPD_ERR_INFO_GET_OPCODE 0xFB38
+#define DDR_SPD_ERR_TYPE_SUPPORTED 2
+struct ddr_spd_err_details{
+  uint32_t spd_err_cnt;
+  uint32_t offset;
+} __attribute__((packed));
+
+struct ddr_spd_err{
+  struct ddr_spd_err_details spd_err_detail[2];
+} __attribute__((packed));
+
+struct ddr_spd_err_info{
+	struct ddr_spd_err spd_err_info[4];
+} __attribute__((packed));
+
+struct cxl_mbox_handle_ddr_spd_err_info_out {
+  struct ddr_spd_err_info ddr_spd_err;
+} __attribute__((packed));
+
+CXL_EXPORT int cxl_memdev_ddr_spd_err_info_get(struct cxl_memdev *memdev)
+{
+    struct cxl_cmd *cmd;
+    struct cxl_mem_query_commands *query;
+    struct cxl_command_info *cinfo;
+    struct  cxl_mbox_handle_ddr_spd_err_info_out *handle_ddr_spd_err_info_out;
+    int rc = 0;
+    int i = 0,j = 0;
+    char *spd_err_type[2] = {"SPD_CRC","SPD_NULL_DATA"};
+    cmd = cxl_cmd_new_raw(memdev, CXL_MEM_COMMAND_ID_CXL_DDR_SPD_ERR_INFO_GET_OPCODE);
+    if (!cmd) {
+        fprintf(stderr, "%s: cxl_cmd_new_raw returned Null output\n",
+                cxl_memdev_get_devname(memdev));
+        return -ENOMEM;
+    }
+
+    query = cmd->query_cmd;
+    cinfo = &query->commands[cmd->query_idx];
+
+    /* used to force correct payload size */
+    cinfo->size_in = 0; //CXL_MEM_COMMAND_ID_LOG_INFO_PAYLOAD_IN_SIZE;
+    if (cinfo->size_in > 0) {
+        cmd->input_payload = calloc(1, cinfo->size_in);
+        if (!cmd->input_payload)
+            return -ENOMEM;
+        cmd->send_cmd->in.payload = (u64)cmd->input_payload;
+        cmd->send_cmd->in.size = cinfo->size_in;
+    }
+
+    rc = cxl_cmd_submit(cmd);
+    if (rc < 0) {
+        fprintf(stderr, "%s: cmd submission failed: %d (%s)\n",
+                cxl_memdev_get_devname(memdev), rc, strerror(-rc));
+        goto out;
+    }
+
+    rc = cxl_cmd_get_mbox_status(cmd);
+    if (rc != 0) {
+        fprintf(stderr, "%s: firmware status: %d\n",
+                cxl_memdev_get_devname(memdev), rc);
+        goto out;
+    }
+
+    if (cmd->send_cmd->id != CXL_MEM_COMMAND_ID_CXL_DDR_SPD_ERR_INFO_GET) {
+        fprintf(stderr, "%s: invalid command id 0x%x (expecting 0x%x)\n",
+                cxl_memdev_get_devname(memdev), cmd->send_cmd->id,
+                CXL_MEM_COMMAND_ID_CXL_DDR_SPD_ERR_INFO_GET);
+        return -EINVAL;
+    }
+
+    handle_ddr_spd_err_info_out = (struct cxl_mbox_handle_ddr_spd_err_info_out *)cmd->send_cmd->out.payload;
+
+    fprintf(stdout, "SPD error  details \n");
+    for(i = 0; i < DDR_MAX_DIMM_CNT; i++)
+    {
+	for(j = 0; j < DDR_SPD_ERR_TYPE_SUPPORTED; j++)
+	{
+	    fprintf(stdout, "DIMM_Id(%d) spd_err_type (%s) count (%d) offset (%d)\n",i, spd_err_type[j],
+			    handle_ddr_spd_err_info_out->ddr_spd_err.spd_err_info[i].spd_err_detail[j].spd_err_cnt,
+			    handle_ddr_spd_err_info_out->ddr_spd_err.spd_err_info[i].spd_err_detail[j].offset);
+	}
+    }
+out:
+    cxl_cmd_unref(cmd);
+    return rc;
+}
+
+/* DDR SPD ERROR INFO CLR */
+#define CXL_MEM_COMMAND_ID_CXL_DDR_SPD_ERR_INFO_CLR CXL_MEM_COMMAND_ID_RAW
+#define CXL_MEM_COMMAND_ID_CXL_DDR_SPD_ERR_INFO_CLR_OPCODE 0xFB39
+
+CXL_EXPORT int cxl_memdev_ddr_spd_err_info_clr(struct cxl_memdev *memdev)
+{
+    struct cxl_cmd *cmd;
+    struct cxl_mem_query_commands *query;
+    struct cxl_command_info *cinfo;
+    int rc = 0;
+    int i = 0;
+    cmd = cxl_cmd_new_raw(memdev, CXL_MEM_COMMAND_ID_CXL_DDR_SPD_ERR_INFO_CLR_OPCODE);
+    if (!cmd) {
+        fprintf(stderr, "%s: cxl_cmd_new_raw returned Null output\n",
+                cxl_memdev_get_devname(memdev));
+        return -ENOMEM;
+    }
+
+    query = cmd->query_cmd;
+    cinfo = &query->commands[cmd->query_idx];
+
+    /* used to force correct payload size */
+    cinfo->size_in = 0; //CXL_MEM_COMMAND_ID_LOG_INFO_PAYLOAD_IN_SIZE;
+    if (cinfo->size_in > 0) {
+        cmd->input_payload = calloc(1, cinfo->size_in);
+        if (!cmd->input_payload)
+            return -ENOMEM;
+        cmd->send_cmd->in.payload = (u64)cmd->input_payload;
+        cmd->send_cmd->in.size = cinfo->size_in;
+    }
+
+    rc = cxl_cmd_submit(cmd);
+    if (rc < 0) {
+        fprintf(stderr, "%s: cmd submission failed: %d (%s)\n",
+                cxl_memdev_get_devname(memdev), rc, strerror(-rc));
+        goto out;
+    }
+
+    rc = cxl_cmd_get_mbox_status(cmd);
+    if (rc != 0) {
+        fprintf(stderr, "%s: firmware status: %d\n",
+                cxl_memdev_get_devname(memdev), rc);
+        goto out;
+    }
+
+    if (cmd->send_cmd->id != CXL_MEM_COMMAND_ID_CXL_DDR_SPD_ERR_INFO_CLR) {
+        fprintf(stderr, "%s: invalid command id 0x%x (expecting 0x%x)\n",
+                cxl_memdev_get_devname(memdev), cmd->send_cmd->id,
+                CXL_MEM_COMMAND_ID_CXL_DDR_SPD_ERR_INFO_CLR);
+        return -EINVAL;
+    }
+
+out:
+    cxl_cmd_unref(cmd);
+    return rc;
+}

--- a/cxl/lib/libcxl.sym
+++ b/cxl/lib/libcxl.sym
@@ -225,4 +225,6 @@ global:
     cxl_memdev_ddr_freq_get;
     cxl_memdev_ddr_init_err_info_get;
     cxl_memdev_ddr_bist_err_info_clr;
+    cxl_memdev_ddr_spd_err_info_get;
+    cxl_memdev_ddr_spd_err_info_clr;
 } LIBCXL_3;

--- a/cxl/libcxl.h
+++ b/cxl/libcxl.h
@@ -294,6 +294,8 @@ int cxl_memdev_cxl_err_cnt_get(struct cxl_memdev *memdev);
 int cxl_memdev_ddr_freq_get(struct cxl_memdev *memdev);
 int cxl_memdev_ddr_init_err_info_get(struct cxl_memdev *memdev);
 int cxl_memdev_ddr_bist_err_info_clr(struct cxl_memdev *memdev);
+int cxl_memdev_ddr_spd_err_info_get(struct cxl_memdev *memdev);
+int cxl_memdev_ddr_spd_err_info_clr(struct cxl_memdev *memdev);
 
 #define cxl_memdev_foreach(ctx, memdev) \
         for (memdev = cxl_memdev_get_first(ctx); \

--- a/cxl/memdev.c
+++ b/cxl/memdev.c
@@ -2443,6 +2443,16 @@ static const struct option cmd_cxl_ddr_bist_err_info_clr_options[] = {
   OPT_END(),
 };
 
+static const struct option cmd_cxl_ddr_spd_err_info_get_options[] = {
+  BASE_OPTIONS(),
+  OPT_END(),
+};
+
+static const struct option cmd_cxl_ddr_spd_err_info_clr_options[] = {
+  BASE_OPTIONS(),
+  OPT_END(),
+};
+
 static int action_cmd_clear_event_records(struct cxl_memdev *memdev, struct action_context *actx)
 {
   u16 record_handle;
@@ -6190,6 +6200,49 @@ int cmd_cxl_ddr_bist_err_info_clr(int argc, const char **argv, struct cxl_ctx *c
         argc, argv, ctx, action_cmd_cxl_ddr_bist_err_info_clr,
         cmd_cxl_ddr_bist_err_info_clr_options,
         "cxl cxl-ddr-bist-err-info-clr <mem0> [<mem1>..<memN>] [<options>]");
+
+    return rc >= 0 ? 0 : EXIT_FAILURE;
+}
+static int action_cmd_cxl_ddr_spd_err_info_get(struct cxl_memdev *memdev,
+                      struct action_context *actx)
+{
+    if (cxl_memdev_is_active(memdev)) {
+        fprintf(stderr, "%s: memdev active, cxl get spd error info\n",
+            cxl_memdev_get_devname(memdev));
+        return -EBUSY;
+    }
+
+    return cxl_memdev_ddr_spd_err_info_get(memdev);
+}
+
+int cmd_cxl_ddr_spd_err_info_get(int argc, const char **argv, struct cxl_ctx *ctx)
+{
+    int rc = memdev_action(
+        argc, argv, ctx, action_cmd_cxl_ddr_spd_err_info_get,
+        cmd_cxl_ddr_spd_err_info_get_options,
+        "cxl cxl-ddr-spd-err-info-get <mem0> [<mem1>..<memN>] [<options>]");
+
+    return rc >= 0 ? 0 : EXIT_FAILURE;
+}
+
+static int action_cmd_cxl_ddr_spd_err_info_clr(struct cxl_memdev *memdev,
+                      struct action_context *actx)
+{
+    if (cxl_memdev_is_active(memdev)) {
+        fprintf(stderr, "%s: memdev active, cxl clr spd error info\n",
+            cxl_memdev_get_devname(memdev));
+        return -EBUSY;
+    }
+
+    return cxl_memdev_ddr_spd_err_info_clr(memdev);
+}
+
+int cmd_cxl_ddr_spd_err_info_clr(int argc, const char **argv, struct cxl_ctx *ctx)
+{
+    int rc = memdev_action(
+        argc, argv, ctx, action_cmd_cxl_ddr_spd_err_info_clr,
+        cmd_cxl_ddr_spd_err_info_clr_options,
+        "cxl cxl-ddr-spd-err-info-clr <mem0> [<mem1>..<memN>] [<options>]");
 
     return rc >= 0 ? 0 : EXIT_FAILURE;
 }


### PR DESCRIPTION
Summary:
In this task, mailbox command to store and clear DDR SPD error is implemented.
- here 2 types of SPD errors are handled . Type 0 is SPD CRC ERROR and TYPE 1 is SPD NULL DATA ERROR
- TYPE 0(SPD CRC) ERROR is checked for all 4 DIMMs and if error is found, when comparing calculated CRC with available CRC, then DIMM_ID and the offset is stored in NVDATA
- TYPE 1(SPD NULL DATA) ERROR is checked for all 4 DIMMs and if error is found,when reading first 4 bytes of the reading address, then DIMM_ID and the offset is stored in NVDATA
- MailBox command ddr-err-spd-info-get(0xFB38) is implemented to retrive this error information from persistent memory (NVDATA) and send as a response to this command.
- MailBox command ddr-err-spd-info-clr(0xFB39) is implemented to clear this error information from NVDATA (persistent memory)

Test Plan:
1) Modify the code to generate SPD NULL DATA error and if found then store the information in NVDATA. 2) Retrive the error information using ./cxl ddr-err-spd-info-get mem0/mem1 3) Reboot the host and again check if the information is persist 4) Clear this error information using ./cxl ddr-err-spd-info-clr mem0/mem1 5) Retrive the error information using ./cxl ddr-err-spd-info-get mem0/mem1 6) Reboot the host and again check if the information is persist

Reviewers:

Subscribers:

Tasks:

Tags: