### PR TITLE
VISTARA : MailBox command implementation for DDR SPD error info clear for dimm_id requested

### DIFF
--- a/cxl/builtin.h
+++ b/cxl/builtin.h
@@ -168,4 +168,6 @@ int cmd_cxl_err_cnt_get(int argc, const char **argv, struct cxl_ctx *ctx);
 int cmd_ddr_freq_get(int argc, const char **argv, struct cxl_ctx *ctx);
 int cmd_cxl_ddr_bist_err_info_get(int argc, const char **argv, struct cxl_ctx *ctx);
 int cmd_cxl_ddr_bist_err_info_clr(int argc, const char **argv, struct cxl_ctx *ctx);
+int cmd_cxl_ddr_spd_err_info_get(int argc, const char **argv, struct cxl_ctx *ctx);
+int cmd_cxl_ddr_spd_err_info_clr(int argc, const char **argv, struct cxl_ctx *ctx);
 #endif /* _CXL_BUILTIN_H_ */

--- a/cxl/cxl.c
+++ b/cxl/cxl.c
@@ -224,6 +224,8 @@ static struct cmd_struct commands[] = {
 	{ "ddr-freq-get", .c_fn = cmd_ddr_freq_get },
 	{ "ddr-err-bist-info-get", .c_fn = cmd_cxl_ddr_bist_err_info_get },
 	{ "ddr-err-bist-info-clr", .c_fn = cmd_cxl_ddr_bist_err_info_clr },
+	{ "ddr-err-spd-info-get", .c_fn = cmd_cxl_ddr_spd_err_info_get },
+	{ "ddr-err-spd-info-clr", .c_fn = cmd_cxl_ddr_spd_err_info_clr },
 };
 
 int main(int argc, const char **argv)

--- a/cxl/lib/libcxl.c
+++ b/cxl/lib/libcxl.c
@@ -15398,10 +15398,11 @@ out:
 }
 
 /* DDR INIT ERROR INFO GET */
-#define CXL_MEM_COMMAND_ID_CXL_DDR_INIT_ERR_INFO_GET CXL_MEM_COMMAND_ID_RAW
-#define CXL_MEM_COMMAND_ID_CXL_DDR_INIT_ERR_INFO_GET_OPCODE 0xFB36
+#define CXL_MEM_COMMAND_ID_CXL_DDR_BIST_ERR_INFO_GET CXL_MEM_COMMAND_ID_RAW
+#define CXL_MEM_COMMAND_ID_CXL_DDR_BIST_ERR_INFO_GET_OPCODE 0xFB36
 
-struct ddr_init_bist_err_info{
+//to support cmd CXL_MBOX_OP_DDR_BIST_ERR_INFO_GET, CXL_MBOX_OP_DDR_BIST_ERR_INFO_CLR
+struct ddr_bist_err_details{
   uint32_t ddr_bist_err_cnt;
   uint32_t ddr_bist_err_info_col;
   uint32_t ddr_bist_err_info_row;
@@ -15409,24 +15410,23 @@ struct ddr_init_bist_err_info{
   uint16_t ddr_bist_err_info_cs;
 } __attribute__((packed));
 
-struct ddr_init_err_info{
-  struct ddr_init_bist_err_info ddr_bist_err_info[2];
+struct ddr_bist_err_info{
+  struct ddr_bist_err_details ddr_bist_err_get_info[2];
 } __attribute__((packed));
 
-
-struct cxl_mbox_handle_ddr_init_err_info_out {
-  struct ddr_init_err_info ddr_init_err;
+struct cxl_mbox_handle_ddr_bist_err_info_out {
+  struct ddr_bist_err_info ddr_bist_err;
 } __attribute__((packed));
 
-CXL_EXPORT int cxl_memdev_ddr_init_err_info_get(struct cxl_memdev *memdev)
+CXL_EXPORT int cxl_memdev_ddr_bist_err_info_get(struct cxl_memdev *memdev)
 {
     struct cxl_cmd *cmd;
     struct cxl_mem_query_commands *query;
     struct cxl_command_info *cinfo;
-    struct  cxl_mbox_handle_ddr_init_err_info_out *handle_ddr_init_err_info_out;
+    struct  cxl_mbox_handle_ddr_bist_err_info_out *handle_ddr_bist_err_info_out;
     int rc = 0;
     int i = 0;
-    cmd = cxl_cmd_new_raw(memdev, CXL_MEM_COMMAND_ID_CXL_DDR_INIT_ERR_INFO_GET_OPCODE);
+    cmd = cxl_cmd_new_raw(memdev, CXL_MEM_COMMAND_ID_CXL_DDR_BIST_ERR_INFO_GET_OPCODE);
     if (!cmd) {
         fprintf(stderr, "%s: cxl_cmd_new_raw returned Null output\n",
                 cxl_memdev_get_devname(memdev));
@@ -15460,28 +15460,28 @@ CXL_EXPORT int cxl_memdev_ddr_init_err_info_get(struct cxl_memdev *memdev)
         goto out;
     }
 
-    if (cmd->send_cmd->id != CXL_MEM_COMMAND_ID_CXL_DDR_INIT_ERR_INFO_GET) {
+    if (cmd->send_cmd->id != CXL_MEM_COMMAND_ID_CXL_DDR_BIST_ERR_INFO_GET) {
         fprintf(stderr, "%s: invalid command id 0x%x (expecting 0x%x)\n",
                 cxl_memdev_get_devname(memdev), cmd->send_cmd->id,
-                CXL_MEM_COMMAND_ID_CXL_DDR_INIT_ERR_INFO_GET);
+                CXL_MEM_COMMAND_ID_CXL_DDR_BIST_ERR_INFO_GET);
         return -EINVAL;
     }
 
-    handle_ddr_init_err_info_out = (struct cxl_mbox_handle_ddr_init_err_info_out *)cmd->send_cmd->out.payload;
+    handle_ddr_bist_err_info_out = (struct cxl_mbox_handle_ddr_bist_err_info_out *)cmd->send_cmd->out.payload;
 
     for(i = 0; i < 2; i++)
     {
 	fprintf(stdout, "BIST error details for DDR (%d) \n",i);
 	fprintf(stdout, "DDR BIST error count %d\n",
-            handle_ddr_init_err_info_out->ddr_init_err.ddr_bist_err_info[i].ddr_bist_err_cnt);
+            handle_ddr_bist_err_info_out->ddr_bist_err.ddr_bist_err_get_info[i].ddr_bist_err_cnt);
         fprintf(stdout, "DDR BIST error info (col)%d\n",
-            handle_ddr_init_err_info_out->ddr_init_err.ddr_bist_err_info[i].ddr_bist_err_info_col);
+            handle_ddr_bist_err_info_out->ddr_bist_err.ddr_bist_err_get_info[i].ddr_bist_err_info_col);
         fprintf(stdout, "DDR BIST error info (row)%d\n",
-            handle_ddr_init_err_info_out->ddr_init_err.ddr_bist_err_info[i].ddr_bist_err_info_row);
+            handle_ddr_bist_err_info_out->ddr_bist_err.ddr_bist_err_get_info[i].ddr_bist_err_info_row);
         fprintf(stdout, "DDR BIST error info (bank)%d\n",
-            handle_ddr_init_err_info_out->ddr_init_err.ddr_bist_err_info[i].ddr_bist_err_info_bank);
+            handle_ddr_bist_err_info_out->ddr_bist_err.ddr_bist_err_get_info[i].ddr_bist_err_info_bank);
         fprintf(stdout, "DDR BIST error info (cs)%d\n",
-            handle_ddr_init_err_info_out->ddr_init_err.ddr_bist_err_info[i].ddr_bist_err_info_cs);
+            handle_ddr_bist_err_info_out->ddr_bist_err.ddr_bist_err_get_info[i].ddr_bist_err_info_cs);
     }
 out:
     cxl_cmd_unref(cmd);
@@ -15536,6 +15536,168 @@ CXL_EXPORT int cxl_memdev_ddr_bist_err_info_clr(struct cxl_memdev *memdev)
         fprintf(stderr, "%s: invalid command id 0x%x (expecting 0x%x)\n",
                 cxl_memdev_get_devname(memdev), cmd->send_cmd->id,
                 CXL_MEM_COMMAND_ID_CXL_DDR_BIST_ERR_INFO_CLR);
+        return -EINVAL;
+    }
+
+out:
+    cxl_cmd_unref(cmd);
+    return rc;
+}
+
+/* DDR SPD ERROR INFO GET */
+#define CXL_MEM_COMMAND_ID_CXL_DDR_SPD_ERR_INFO_GET CXL_MEM_COMMAND_ID_RAW
+#define CXL_MEM_COMMAND_ID_CXL_DDR_SPD_ERR_INFO_GET_OPCODE 0xFB38
+#define DDR_SPD_ERR_TYPE_SUPPORTED 2
+struct ddr_spd_err_details{
+  uint16_t spd_err_cnt;
+  uint16_t offset;
+} __attribute__((packed));
+
+struct ddr_spd_err{
+  struct ddr_spd_err_details spd_err_detail[DDR_SPD_ERR_TYPE_SUPPORTED];
+} __attribute__((packed));
+
+struct ddr_spd_err_info{
+	struct ddr_spd_err spd_err_info[DDR_MAX_DIMM_CNT];
+} __attribute__((packed));
+
+struct cxl_mbox_handle_ddr_spd_err_info_out {
+  struct ddr_spd_err_info ddr_spd_err;
+} __attribute__((packed));
+
+CXL_EXPORT int cxl_memdev_ddr_spd_err_info_get(struct cxl_memdev *memdev)
+{
+    struct cxl_cmd *cmd;
+    struct cxl_mem_query_commands *query;
+    struct cxl_command_info *cinfo;
+    struct  cxl_mbox_handle_ddr_spd_err_info_out *handle_ddr_spd_err_info_out;
+    int rc = 0;
+    int i = 0,j = 0;
+    char *spd_err_type[DDR_SPD_ERR_TYPE_SUPPORTED] = {"SPD_CRC","SPD_NULL_DATA"};
+    cmd = cxl_cmd_new_raw(memdev, CXL_MEM_COMMAND_ID_CXL_DDR_SPD_ERR_INFO_GET_OPCODE);
+    if (!cmd) {
+        fprintf(stderr, "%s: cxl_cmd_new_raw returned Null output\n",
+                cxl_memdev_get_devname(memdev));
+        return -ENOMEM;
+    }
+
+    query = cmd->query_cmd;
+    cinfo = &query->commands[cmd->query_idx];
+
+    /* used to force correct payload size */
+    cinfo->size_in = 0; //CXL_MEM_COMMAND_ID_LOG_INFO_PAYLOAD_IN_SIZE;
+    if (cinfo->size_in > 0) {
+        cmd->input_payload = calloc(1, cinfo->size_in);
+        if (!cmd->input_payload)
+            return -ENOMEM;
+        cmd->send_cmd->in.payload = (u64)cmd->input_payload;
+        cmd->send_cmd->in.size = cinfo->size_in;
+    }
+
+    rc = cxl_cmd_submit(cmd);
+    if (rc < 0) {
+        fprintf(stderr, "%s: cmd submission failed: %d (%s)\n",
+                cxl_memdev_get_devname(memdev), rc, strerror(-rc));
+        goto out;
+    }
+
+    rc = cxl_cmd_get_mbox_status(cmd);
+    if (rc != 0) {
+        fprintf(stderr, "%s: firmware status: %d\n",
+                cxl_memdev_get_devname(memdev), rc);
+        goto out;
+    }
+
+    if (cmd->send_cmd->id != CXL_MEM_COMMAND_ID_CXL_DDR_SPD_ERR_INFO_GET) {
+        fprintf(stderr, "%s: invalid command id 0x%x (expecting 0x%x)\n",
+                cxl_memdev_get_devname(memdev), cmd->send_cmd->id,
+                CXL_MEM_COMMAND_ID_CXL_DDR_SPD_ERR_INFO_GET);
+        return -EINVAL;
+    }
+
+    handle_ddr_spd_err_info_out = (struct cxl_mbox_handle_ddr_spd_err_info_out *)cmd->send_cmd->out.payload;
+
+    fprintf(stdout, "SPD error  details \n");
+    for(i = 0; i < DDR_MAX_DIMM_CNT; i++)
+    {
+	fprintf(stdout, "DIMM_Id(%d): \n",i);
+	for(j = 0; j < DDR_SPD_ERR_TYPE_SUPPORTED; j++)
+	{
+	    fprintf(stdout, "\t spd_err_type (%s) \n\t\t count (%d) offset (%d)\n", spd_err_type[j],
+			    handle_ddr_spd_err_info_out->ddr_spd_err.spd_err_info[i].spd_err_detail[j].spd_err_cnt,
+			    handle_ddr_spd_err_info_out->ddr_spd_err.spd_err_info[i].spd_err_detail[j].offset);
+	}
+    }
+out:
+    cxl_cmd_unref(cmd);
+    return rc;
+}
+
+/* DDR SPD ERROR INFO CLR */
+#define CXL_MEM_COMMAND_ID_CXL_DDR_SPD_ERR_INFO_CLR CXL_MEM_COMMAND_ID_RAW
+#define CXL_MEM_COMMAND_ID_CXL_DDR_SPD_ERR_INFO_CLR_OPCODE 0xFB39
+#define CXL_MEM_COMMAND_ID_CXL_DDR_SPD_DIMM_ID 1
+struct cxl_mbox_handle_clr_spd_dimm_id_in {
+  u8 dimm_id;
+} __attribute__ ((packed));
+
+CXL_EXPORT int cxl_memdev_ddr_spd_err_info_clr(struct cxl_memdev *memdev, u8 spd_er_clr_dimm_id_option)
+{
+    struct cxl_cmd *cmd;
+    struct cxl_mem_query_commands *query;
+    struct cxl_command_info *cinfo;
+    int rc = 0;
+    struct cxl_mbox_handle_clr_spd_dimm_id_in *handle_spd_clr_dimm_id_detail;
+    cmd = cxl_cmd_new_raw(memdev, CXL_MEM_COMMAND_ID_CXL_DDR_SPD_ERR_INFO_CLR_OPCODE);
+   
+    if (!cmd) {
+        fprintf(stderr, "%s: cxl_cmd_new_raw returned Null output\n",
+                cxl_memdev_get_devname(memdev));
+        return -ENOMEM;
+    }
+
+    query = cmd->query_cmd;
+    cinfo = &query->commands[cmd->query_idx];
+
+    /* update payload size */
+    cinfo->size_in = CXL_MEM_COMMAND_ID_CXL_DDR_SPD_DIMM_ID;
+    if (cinfo->size_in > 0) {
+        cmd->input_payload = calloc(1, cinfo->size_in);
+        if (!cmd->input_payload)
+            return -ENOMEM;
+        cmd->send_cmd->in.payload = (u64)cmd->input_payload;
+        cmd->send_cmd->in.size = cinfo->size_in;
+    }
+
+    if(spd_er_clr_dimm_id_option > 3 && spd_er_clr_dimm_id_option < 0xFF)
+    {
+        fprintf(stderr, "%s: invalid input options 0x%x (Expecting option 0,1,2,3,0xFF)\n",
+                     cxl_memdev_get_devname(memdev), spd_er_clr_dimm_id_option);
+        return -EINVAL;
+    }
+    
+    handle_spd_clr_dimm_id_detail = (void *) cmd->send_cmd->in.payload;
+
+    handle_spd_clr_dimm_id_detail->dimm_id = spd_er_clr_dimm_id_option;
+
+    rc = cxl_cmd_submit(cmd);
+    if (rc < 0) {
+        fprintf(stderr, "%s: cmd submission failed: %d (%s)\n",
+                cxl_memdev_get_devname(memdev), rc, strerror(-rc));
+        goto out;
+    }
+	
+    rc = cxl_cmd_get_mbox_status(cmd);
+    if (rc != 0) {
+        fprintf(stderr, "%s: firmware status: %d\n",
+                cxl_memdev_get_devname(memdev), rc);
+        goto out;
+    }
+
+    if (cmd->send_cmd->id != CXL_MEM_COMMAND_ID_CXL_DDR_SPD_ERR_INFO_CLR) {
+        fprintf(stderr, "%s: invalid command id 0x%x (expecting 0x%x)\n",
+                cxl_memdev_get_devname(memdev), cmd->send_cmd->id,
+                CXL_MEM_COMMAND_ID_CXL_DDR_SPD_ERR_INFO_CLR);
         return -EINVAL;
     }
 

--- a/cxl/lib/libcxl.sym
+++ b/cxl/lib/libcxl.sym
@@ -223,6 +223,8 @@ global:
     cxl_memdev_ddr_refresh_mode_get;
     cxl_memdev_cxl_err_cnt_get;
     cxl_memdev_ddr_freq_get;
-    cxl_memdev_ddr_init_err_info_get;
+    cxl_memdev_ddr_bist_err_info_get;
     cxl_memdev_ddr_bist_err_info_clr;
+    cxl_memdev_ddr_spd_err_info_get;
+    cxl_memdev_ddr_spd_err_info_clr;
 } LIBCXL_3;

--- a/cxl/libcxl.h
+++ b/cxl/libcxl.h
@@ -292,8 +292,10 @@ int cxl_memdev_ddr_refresh_mode_set(struct cxl_memdev *memdev, u8 refresh_select
 int cxl_memdev_ddr_refresh_mode_get(struct cxl_memdev *memdev);
 int cxl_memdev_cxl_err_cnt_get(struct cxl_memdev *memdev);
 int cxl_memdev_ddr_freq_get(struct cxl_memdev *memdev);
-int cxl_memdev_ddr_init_err_info_get(struct cxl_memdev *memdev);
+int cxl_memdev_ddr_bist_err_info_get(struct cxl_memdev *memdev);
 int cxl_memdev_ddr_bist_err_info_clr(struct cxl_memdev *memdev);
+int cxl_memdev_ddr_spd_err_info_get(struct cxl_memdev *memdev);
+int cxl_memdev_ddr_spd_err_info_clr(struct cxl_memdev *memdev, u8 spd_err_clr_dimm_id_option);
 
 #define cxl_memdev_foreach(ctx, memdev) \
         for (memdev = cxl_memdev_get_first(ctx); \

--- a/cxl/memdev.c
+++ b/cxl/memdev.c
@@ -2443,6 +2443,28 @@ static const struct option cmd_cxl_ddr_bist_err_info_clr_options[] = {
   OPT_END(),
 };
 
+static const struct option cmd_cxl_ddr_spd_err_info_get_options[] = {
+  BASE_OPTIONS(),
+  OPT_END(),
+};
+
+static struct _spd_err_clr_param{
+  u32 dimm_id;
+} spd_err_clr_param;
+
+#define CLR_SPD_ERR_FOR_DIMM() \
+  OPT_UINTEGER('i', "dimm_id", &spd_err_clr_param.dimm_id, "Clear DDR SPD error data for dimm_id(valid i values : 0,1,2,3,0xFF). \
+                  \n\t\t\t  (0 - DIMM_A), \
+                  \n\t\t\t  (1 - DIMM_B), \
+                  \n\t\t\t  (2 - DIMM_D), \
+                  \n\t\t\t  (3 - DIMM_C), \
+                  \n\t\t\t  (0xFF - ALL_DIMM)")
+static const struct option cmd_cxl_ddr_spd_err_info_clr_options[] = {
+  BASE_OPTIONS(),
+  CLR_SPD_ERR_FOR_DIMM(),
+  OPT_END(),
+};
+
 static int action_cmd_clear_event_records(struct cxl_memdev *memdev, struct action_context *actx)
 {
   u16 record_handle;
@@ -6159,7 +6181,7 @@ static int action_cmd_cxl_ddr_bist_err_info_get(struct cxl_memdev *memdev,
         return -EBUSY;
     }
 
-    return cxl_memdev_ddr_init_err_info_get(memdev);
+    return cxl_memdev_ddr_bist_err_info_get(memdev);
 }
 
 static int action_cmd_cxl_ddr_bist_err_info_clr(struct cxl_memdev *memdev,
@@ -6190,6 +6212,49 @@ int cmd_cxl_ddr_bist_err_info_clr(int argc, const char **argv, struct cxl_ctx *c
         argc, argv, ctx, action_cmd_cxl_ddr_bist_err_info_clr,
         cmd_cxl_ddr_bist_err_info_clr_options,
         "cxl cxl-ddr-bist-err-info-clr <mem0> [<mem1>..<memN>] [<options>]");
+
+    return rc >= 0 ? 0 : EXIT_FAILURE;
+}
+
+static int action_cmd_cxl_ddr_spd_err_info_get(struct cxl_memdev *memdev,
+                      struct action_context *actx)
+{
+    if (cxl_memdev_is_active(memdev)) {
+        fprintf(stderr, "%s: memdev active, cxl get spd error info\n",
+            cxl_memdev_get_devname(memdev));
+        return -EBUSY;
+    }
+
+    return cxl_memdev_ddr_spd_err_info_get(memdev);
+}
+
+int cmd_cxl_ddr_spd_err_info_get(int argc, const char **argv, struct cxl_ctx *ctx)
+{
+    int rc = memdev_action(
+        argc, argv, ctx, action_cmd_cxl_ddr_spd_err_info_get,
+        cmd_cxl_ddr_spd_err_info_get_options,
+        "cxl cxl-ddr-spd-err-info-get <mem0> [<mem1>..<memN>] [<options>]");
+
+    return rc >= 0 ? 0 : EXIT_FAILURE;
+}
+
+static int action_cmd_cxl_ddr_spd_err_info_clr(struct cxl_memdev *memdev,
+                      struct action_context *actx)
+{
+    if (cxl_memdev_is_active(memdev)) {
+        fprintf(stderr, "%s: memdev active, cxl clr spd error info\n",
+            cxl_memdev_get_devname(memdev));
+        return -EBUSY;
+    }
+    return cxl_memdev_ddr_spd_err_info_clr(memdev, spd_err_clr_param.dimm_id);
+}
+
+int cmd_cxl_ddr_spd_err_info_clr(int argc, const char **argv, struct cxl_ctx *ctx)
+{
+    int rc = memdev_action(
+        argc, argv, ctx, action_cmd_cxl_ddr_spd_err_info_clr,
+        cmd_cxl_ddr_spd_err_info_clr_options,
+        "cxl cxl-ddr-spd-err-info-clr <mem0> [<mem1>..<memN>] [<options>] ");
 
     return rc >= 0 ? 0 : EXIT_FAILURE;
 }


### PR DESCRIPTION
Summary:
In this task, mailbox command to store and clear DDR SPD error is implemented. here 2 types of SPD errors are handled . 
- Type 0 is SPD CRC ERROR and TYPE 1 is SPD NULL DATA ERROR TYPE 0(SPD CRC) ERROR is checked for all 4 DIMMs and if error is found, when comparing calculated CRC with available CRC, then DIMM_ID and the offset is stored in NVDATA
- TYPE 1(SPD NULL DATA) ERROR is checked for all 4 DIMMs and if error is found, when reading first 4 bytes of the reading address, then DIMM_ID and the offset is stored in NVDATA
- MailBox command ddr-err-spd-info-get(0xFB38) is implemented to retrieve this error information from persistent memory (NVDATA) and send as a response to this command. 
- MailBox command ddr-err-spd-info-clr(0xFB39) is implemented to clear this error information from NVDATA (persistent memory)
- Code cleanup for MailBox command ddr-err-bist-info-get(0xFB36) 
- 
Test Plan:
1. Modify the code to generate SPD NULL DATA error and if found then store the information in NVDATA.
2. Retrieve the error information using ./cxl ddr-err-spd-info-get mem0/mem1
3. Reboot the host and again check if the information is persist
4. Clear this error information using ./cxl ddr-err-spd-info-clr mem0/mem1 -i dimm_id
5. Retrieve the error information using ./cxl ddr-err-spd-info-get mem0/mem1
6. Reboot the host and again check if the information is persist

Output
===========================
[root@DG18161 cxl]# ./cxl ddr-err-spd-info-clr 

 usage: cxl cxl-ddr-spd-err-info-clr <mem0> [<mem1>..<memN>] [<options>] 

    -v, --verbose         turn on debug
    -i, --dimm_id <n>     Clear DDR SPD error data for dimm_id(valid i values : 0,1,2,3,0xFF). 		  
			  (0 - DIMM_A), 		  
			  (1 - DIMM_B), 		  
			  (2 - DIMM_D), 		  
			  (3 - DIMM_C), 		  
			  (0xFF - ALL_DIMM)

[root@DG18161 cxl]# ./cxl ddr-err-spd-info-clr mem1 -i 7
mem1: invalid input options 0x7 (Expecting option 0,1,2,3,0xFF)
'''
[root@DG18161 ndctl]# ./cxl/cxl ddr-err-spd-info-get mem1
SPD error  details 
DIMM_Id(0): 
	 spd_err_type (SPD_CRC) 
		 count (6) offset (254)
	 spd_err_type (SPD_NULL_DATA) 
		 count (0) offset (0)
DIMM_Id(1): 
	 spd_err_type (SPD_CRC) 
		 count (0) offset (0)
	 spd_err_type (SPD_NULL_DATA) 
		 count (3) offset (0)
DIMM_Id(2): 
	 spd_err_type (SPD_CRC) 
		 count (6) offset (254)
	 spd_err_type (SPD_NULL_DATA) 
		 count (0) offset (0)
DIMM_Id(3): 
	 spd_err_type (SPD_CRC) 
		 count (6) offset (254)
	 spd_err_type (SPD_NULL_DATA) 
		 count (0) offset (0)
'''
'''
[root@DG18161 ndctl]# ./cxl/cxl ddr-err-spd-info-clr mem1 -i 2
[root@DG18161 ndctl]# ./cxl/cxl ddr-err-spd-info-get mem1
SPD error  details 
DIMM_Id(0): 
	 spd_err_type (SPD_CRC) 
		 count (6) offset (254)
	 spd_err_type (SPD_NULL_DATA) 
		 count (0) offset (0)
DIMM_Id(1): 
	 spd_err_type (SPD_CRC) 
		 count (0) offset (0)
	 spd_err_type (SPD_NULL_DATA) 
		 count (3) offset (0)
DIMM_Id(2): 
	 spd_err_type (SPD_CRC) 
		 count (0) offset (0)
	 spd_err_type (SPD_NULL_DATA) 
		 count (0) offset (0)
DIMM_Id(3): 
	 spd_err_type (SPD_CRC) 
		 count (6) offset (254)
	 spd_err_type (SPD_NULL_DATA) 
		 count (0) offset (0)
'''
Reviewers:

Subscribers:

Tasks:

Tags: