### PR TITLE
[Vistara] Rate Limit Config mailbox implementation

### DIFF
--- a/cxl/builtin.h
+++ b/cxl/builtin.h
@@ -170,4 +170,11 @@ int cmd_cxl_ddr_bist_err_info_get(int argc, const char **argv, struct cxl_ctx *c
 int cmd_cxl_ddr_bist_err_info_clr(int argc, const char **argv, struct cxl_ctx *ctx);
 int cmd_cxl_ddr_spd_err_info_get(int argc, const char **argv, struct cxl_ctx *ctx);
 int cmd_cxl_ddr_spd_err_info_clr(int argc, const char **argv, struct cxl_ctx *ctx);
+int cmd_cxl_ddr_irq_status_get(int argc, const char **argv, struct cxl_ctx *ctx);
+int cmd_cxl_ddr_irq_enable_set(int argc, const char **argv, struct cxl_ctx *ctx);
+int cmd_ddr_threshold_set(int argc, const char **argv, struct cxl_ctx *ctx);
+int cmd_ddr_threshold_get(int argc, const char **argv, struct cxl_ctx *ctx);
+int cmd_cxl_threshold_set(int argc, const char **argv, struct cxl_ctx *ctx);
+int cmd_cxl_threshold_get(int argc, const char **argv, struct cxl_ctx *ctx);
+
 #endif /* _CXL_BUILTIN_H_ */

--- a/cxl/cxl.c
+++ b/cxl/cxl.c
@@ -226,6 +226,12 @@ static struct cmd_struct commands[] = {
 	{ "ddr-err-bist-info-clr", .c_fn = cmd_cxl_ddr_bist_err_info_clr },
 	{ "ddr-err-spd-info-get", .c_fn = cmd_cxl_ddr_spd_err_info_get },
 	{ "ddr-err-spd-info-clr", .c_fn = cmd_cxl_ddr_spd_err_info_clr },
+	{ "cxl-ddr-irq-status-get", .c_fn = cmd_cxl_ddr_irq_status_get },
+	{ "cxl-ddr-irq-enable-set", .c_fn = cmd_cxl_ddr_irq_enable_set },
+	{ "ddr-thres-set", .c_fn = cmd_ddr_threshold_set },
+	{ "ddr-thres-get", .c_fn = cmd_ddr_threshold_get },
+	{ "cxl-thres-set", .c_fn = cmd_cxl_threshold_set },
+	{ "cxl-thres-get", .c_fn = cmd_cxl_threshold_get },
 };
 
 int main(int argc, const char **argv)

--- a/cxl/lib/libcxl.sym
+++ b/cxl/lib/libcxl.sym
@@ -227,4 +227,10 @@ global:
     cxl_memdev_ddr_bist_err_info_clr;
     cxl_memdev_ddr_spd_err_info_get;
     cxl_memdev_ddr_spd_err_info_clr;
+    cxl_memdev_cxl_ddr_irq_status_get;
+    cxl_memdev_cxl_ddr_irq_enable_set;
+    cxl_memdev_ddr_threshold_set;
+    cxl_memdev_ddr_threshold_get;
+    cxl_memdev_cxl_threshold_set;
+    cxl_memdev_cxl_threshold_get;
 } LIBCXL_3;

--- a/cxl/libcxl.h
+++ b/cxl/libcxl.h
@@ -296,6 +296,12 @@ int cxl_memdev_ddr_bist_err_info_get(struct cxl_memdev *memdev);
 int cxl_memdev_ddr_bist_err_info_clr(struct cxl_memdev *memdev);
 int cxl_memdev_ddr_spd_err_info_get(struct cxl_memdev *memdev);
 int cxl_memdev_ddr_spd_err_info_clr(struct cxl_memdev *memdev, u8 spd_err_clr_dimm_id_option);
+int cxl_memdev_cxl_ddr_irq_status_get(struct cxl_memdev *memdev);
+int cxl_memdev_cxl_ddr_irq_enable_set(struct cxl_memdev *memdev, u8 irq_num_option);
+int cxl_memdev_ddr_threshold_set(struct cxl_memdev *memdev, u16 corr_err_threshold_cnt, u16 corr_err_time_limit, u16 uncorr_err_threshold_cnt, u16 uncorr_err_time_limit);
+int cxl_memdev_ddr_threshold_get(struct cxl_memdev *memdev);
+int cxl_memdev_cxl_threshold_set(struct cxl_memdev *memdev, u16 corr_err_threshold_cnt, u16 corr_err_time_limit, u16 uncorr_err_threshold_cnt, u16 uncorr_err_time_limit);
+int cxl_memdev_cxl_threshold_get(struct cxl_memdev *memdev);
 
 #define cxl_memdev_foreach(ctx, memdev) \
         for (memdev = cxl_memdev_get_first(ctx); \


### PR DESCRIPTION
Summary:
Rate-limiting mechanism introduced to prevent continuous ISR execution from causing failures. Error Count Limiting: If correctable or uncorrectable errors occur more than set time, the ISR is disabled to prevent indefinite execution. Time-Based Limiting Mechanism: If ISR triggered and reaches threshold within the set time limit. Automatic Reset: If the threshold isn’t exceeded, the error count resets every 2 minutes, preventing unnecessary ISR disablement.

Add support for Rate Limit Config CXL mailbox commands to get IRQ status or enable IRQ and to set and get
IRQ threshold count and time limit.

Test Plan:
Get IRQ status CLI:
./cxl cxl-ddr-irq-status-get mem0
Output:
IRQ Status:
  CXL Correctable IRQ is enabled
  CXL Uncorrectable IRQ is enabled
  CXL Configuration IRQ is enabled
  DDR[0] IRQ is enabled
  DDR[1] IRQ is enabled

Enable IRQ CLI:
./cxl cxl-ddr-irq-enable-set mem0 -i 3
Output:
Enable IRQ line 3

Get Threshold count and Time limit for DDR0 and DDR1 CLI: ./cxl ddr-thres-get mem0
Output:
  Correctable error: threshold count 100, time limit 60
  Uncorrectable error: threshold count 70, time limit 50

Set Threshold count and Time limit for DDR0 and DDR1 CLI: ./cxl ddr-thres-set mem0 -c 5 -t 2 -u 6 -l 3
Output:
  Correctable error: threshold count 5, time limit 2
  Uncorrectable error: threshold count 6, time limit 3

Get Threshold count and Time limit for CXL CLI:
./cxl cxl-thres-get mem0
Output:
  Correctable error: threshold count 100, time limit 60
  Uncorrectable error: threshold count 70, time limit 50

Set Threshold count and Time limit for CXL CLI:
./cxl cxl-thres-set mem0 -c 7 -t 4 -u 8 -l 5
Output:
  Correctable error: threshold count 7, time limit 4
  Uncorrectable error: threshold count 8, time limit 5

Reviewers:

Subscribers:

Tasks:

Tags: