### PR TITLE
VISTARTA : Update DDR INIT STATUS command

### DIFF
--- a/cxl/lib/libcxl.c
+++ b/cxl/lib/libcxl.c
@@ -6388,32 +6388,32 @@ CXL_EXPORT int cxl_memdev_health_counters_get(struct cxl_memdev *memdev)
 
 	health_counters_get_out = (void *)cmd->send_cmd->out.payload;
 	fprintf(stdout, "============================= get health counters ==============================\n");
-	fprintf(stdout, "0: CRITICAL_OVER_TEMPERATURE_EXCEEDED = %d\n", le32_to_cpu(health_counters_get_out->critical_over_temperature_exceeded));
-	fprintf(stdout, "1: OVER_TEMPERATURE_WARNING_LEVEL_EXCEEDED = %d\n", le32_to_cpu(health_counters_get_out->over_temperature_warning_level_exceeded));
-	fprintf(stdout, "2: CRITICAL_UNDER_TEMPERATURE_EXCEEDED = %d\n", le32_to_cpu(health_counters_get_out->critical_under_temperature_exceeded));
-	fprintf(stdout, "3: UNDER_TEMPERATURE_WARNING_LEVEL_EXCEEDED = %d\n", le32_to_cpu(health_counters_get_out->under_temperature_warning_level_exceeded));
-	fprintf(stdout, "4: POWER_ON_EVENTS = %d\n", le32_to_cpu(health_counters_get_out->power_on_events));
-	fprintf(stdout, "5: POWER_ON_HOURS = %d\n", le32_to_cpu(health_counters_get_out->power_on_hours));
-	fprintf(stdout, "6: CXL_MEM_LINK_CRC_ERRORS = %d\n", le32_to_cpu(health_counters_get_out->cxl_mem_link_crc_errors));
-	fprintf(stdout, "7: CXL_IO_LINK_LCRC_ERRORS = %d\n", le32_to_cpu(health_counters_get_out->cxl_io_link_lcrc_errors));
-	fprintf(stdout, "8: CXL_IO_LINK_ECRC_ERRORS = %d\n", le32_to_cpu(health_counters_get_out->cxl_io_link_ecrc_errors));
-	fprintf(stdout, "9: NUM_DDR_COR_ECC_ERRORS = %d\n", le32_to_cpu(health_counters_get_out->num_ddr_correctable_ecc_errors));
-	fprintf(stdout, "10: NUM_DDR_UNCOR_ECC_ERRORS = %d\n", le32_to_cpu(health_counters_get_out->num_ddr_uncorrectable_ecc_errors));
-	fprintf(stdout, "11: LINK_RECOVERY_EVENTS = %d\n", le32_to_cpu(health_counters_get_out->link_recovery_events));
-	fprintf(stdout, "12: TIME_IN_THROTTLED = %d\n", le32_to_cpu(health_counters_get_out->time_in_throttled));
-	fprintf(stdout, "13: RX_RETRY_REQUEST = %d\n", le32_to_cpu(health_counters_get_out->rx_retry_request));
-	fprintf(stdout, "14: RCMD_QS0_HI_THRESHOLD_DETECT = %d\n", le32_to_cpu(health_counters_get_out->rcmd_qs0_hi_threshold_detect));
-	fprintf(stdout, "15: RCMD_QS1_HI_THRESHOLD_DETECT = %d\n", le32_to_cpu(health_counters_get_out->rcmd_qs1_hi_threshold_detect));
-	fprintf(stdout, "16: NUM_PSCAN_COR_ECC_ERRORS = %d\n", le32_to_cpu(health_counters_get_out->num_pscan_correctable_ecc_errors));
-	fprintf(stdout, "17: NUM_PSCAN_UNCOR_ECC_ERRORS = %d\n", le32_to_cpu(health_counters_get_out->num_pscan_uncorrectable_ecc_errors));
-	fprintf(stdout, "18: NUM_DDR_DIMM0_COR_ECC_ERRORS = %d\n", le32_to_cpu(health_counters_get_out->num_ddr_dimm0_correctable_ecc_errors));
-	fprintf(stdout, "19: NUM_DDR_DIMM0_UNCOR_ECC_ERRORS = %d\n", le32_to_cpu(health_counters_get_out->num_ddr_dimm0_uncorrectable_ecc_errors));
-	fprintf(stdout, "20: NUM_DDR_DIMM1_COR_ECC_ERRORS = %d\n", le32_to_cpu(health_counters_get_out->num_ddr_dimm1_correctable_ecc_errors));
-	fprintf(stdout, "21: NUM_DDR_DIMM1_UNCOR_ECC_ERRORS = %d\n", le32_to_cpu(health_counters_get_out->num_ddr_dimm1_uncorrectable_ecc_errors));
-	fprintf(stdout, "22: NUM_DDR_DIMM2_COR_ECC_ERRORS = %d\n", le32_to_cpu(health_counters_get_out->num_ddr_dimm2_correctable_ecc_errors));
-	fprintf(stdout, "23: NUM_DDR_DIMM2_UNCOR_ECC_ERRORS = %d\n", le32_to_cpu(health_counters_get_out->num_ddr_dimm2_uncorrectable_ecc_errors));
-	fprintf(stdout, "24: NUM_DDR_DIMM3_COR_ECC_ERRORS = %d\n", le32_to_cpu(health_counters_get_out->num_ddr_dimm3_correctable_ecc_errors));
-	fprintf(stdout, "25: NUM_DDR_DIMM3_UNCOR_ECC_ERRORS = %d\n", le32_to_cpu(health_counters_get_out->num_ddr_dimm3_uncorrectable_ecc_errors));
+	fprintf(stdout, "0: CRITICAL_OVER_TEMPERATURE_EXCEEDED = %u\n", le32_to_cpu(health_counters_get_out->critical_over_temperature_exceeded));
+	fprintf(stdout, "1: OVER_TEMPERATURE_WARNING_LEVEL_EXCEEDED = %u\n", le32_to_cpu(health_counters_get_out->over_temperature_warning_level_exceeded));
+	fprintf(stdout, "2: CRITICAL_UNDER_TEMPERATURE_EXCEEDED = %u\n", le32_to_cpu(health_counters_get_out->critical_under_temperature_exceeded));
+	fprintf(stdout, "3: UNDER_TEMPERATURE_WARNING_LEVEL_EXCEEDED = %u\n", le32_to_cpu(health_counters_get_out->under_temperature_warning_level_exceeded));
+	fprintf(stdout, "4: POWER_ON_EVENTS = %u\n", le32_to_cpu(health_counters_get_out->power_on_events));
+	fprintf(stdout, "5: POWER_ON_HOURS = %u\n", le32_to_cpu(health_counters_get_out->power_on_hours));
+	fprintf(stdout, "6: CXL_MEM_LINK_CRC_ERRORS = %u\n", le32_to_cpu(health_counters_get_out->cxl_mem_link_crc_errors));
+	fprintf(stdout, "7: CXL_IO_LINK_LCRC_ERRORS = %u\n", le32_to_cpu(health_counters_get_out->cxl_io_link_lcrc_errors));
+	fprintf(stdout, "8: CXL_IO_LINK_ECRC_ERRORS = %u\n", le32_to_cpu(health_counters_get_out->cxl_io_link_ecrc_errors));
+	fprintf(stdout, "9: NUM_DDR_COR_ECC_ERRORS = %u\n", le32_to_cpu(health_counters_get_out->num_ddr_correctable_ecc_errors));
+	fprintf(stdout, "10: NUM_DDR_UNCOR_ECC_ERRORS = %u\n", le32_to_cpu(health_counters_get_out->num_ddr_uncorrectable_ecc_errors));
+	fprintf(stdout, "11: LINK_RECOVERY_EVENTS = %u\n", le32_to_cpu(health_counters_get_out->link_recovery_events));
+	fprintf(stdout, "12: TIME_IN_THROTTLED = %u\n", le32_to_cpu(health_counters_get_out->time_in_throttled));
+	fprintf(stdout, "13: RX_RETRY_REQUEST = %u\n", le32_to_cpu(health_counters_get_out->rx_retry_request));
+	fprintf(stdout, "14: RCMD_QS0_HI_THRESHOLD_DETECT = %u\n", le32_to_cpu(health_counters_get_out->rcmd_qs0_hi_threshold_detect));
+	fprintf(stdout, "15: RCMD_QS1_HI_THRESHOLD_DETECT = %u\n", le32_to_cpu(health_counters_get_out->rcmd_qs1_hi_threshold_detect));
+	fprintf(stdout, "16: NUM_PSCAN_COR_ECC_ERRORS = %u\n", le32_to_cpu(health_counters_get_out->num_pscan_correctable_ecc_errors));
+	fprintf(stdout, "17: NUM_PSCAN_UNCOR_ECC_ERRORS = %u\n", le32_to_cpu(health_counters_get_out->num_pscan_uncorrectable_ecc_errors));
+	fprintf(stdout, "18: NUM_DDR_DIMM0_COR_ECC_ERRORS = %u\n", le32_to_cpu(health_counters_get_out->num_ddr_dimm0_correctable_ecc_errors));
+	fprintf(stdout, "19: NUM_DDR_DIMM0_UNCOR_ECC_ERRORS = %u\n", le32_to_cpu(health_counters_get_out->num_ddr_dimm0_uncorrectable_ecc_errors));
+	fprintf(stdout, "20: NUM_DDR_DIMM1_COR_ECC_ERRORS = %u\n", le32_to_cpu(health_counters_get_out->num_ddr_dimm1_correctable_ecc_errors));
+	fprintf(stdout, "21: NUM_DDR_DIMM1_UNCOR_ECC_ERRORS = %u\n", le32_to_cpu(health_counters_get_out->num_ddr_dimm1_uncorrectable_ecc_errors));
+	fprintf(stdout, "22: NUM_DDR_DIMM2_COR_ECC_ERRORS = %u\n", le32_to_cpu(health_counters_get_out->num_ddr_dimm2_correctable_ecc_errors));
+	fprintf(stdout, "23: NUM_DDR_DIMM2_UNCOR_ECC_ERRORS = %u\n", le32_to_cpu(health_counters_get_out->num_ddr_dimm2_uncorrectable_ecc_errors));
+	fprintf(stdout, "24: NUM_DDR_DIMM3_COR_ECC_ERRORS = %u\n", le32_to_cpu(health_counters_get_out->num_ddr_dimm3_correctable_ecc_errors));
+	fprintf(stdout, "25: NUM_DDR_DIMM3_UNCOR_ECC_ERRORS = %u\n", le32_to_cpu(health_counters_get_out->num_ddr_dimm3_uncorrectable_ecc_errors));
 out:
 	cxl_cmd_unref(cmd);
 	return rc;
@@ -13023,6 +13023,9 @@ typedef enum {
   DDR_INIT_FAILED = -1,
   DDR_INIT_FAILED_NO_CH0_DIMM0 = -2,
   DDR_INIT_FAILED_UNKNOWN_DIMM = -3,
+  DDR_INIT_FAILED_DIMM_SPD_ERR = -4,
+  DDR_INIT_FAILED_DIMM_MPN_DISTINCT = -5,
+  DDR_INIT_FAILED_TIMEOUT = -6,
 } ddr_status;
 
 typedef enum {
@@ -13121,6 +13124,30 @@ CXL_EXPORT int cxl_memdev_ddr_init_status(struct cxl_memdev *memdev)
 		case DDR_INIT_FAILED_UNKNOWN_DIMM:
 				fprintf(stdout, "DDR INIT FAILED. UN-SUPPORTED/UNKNOWN DIMM\n");
 				fprintf(stdout, "RECOVERY REMEDY: PLUG IN SUPPORTED DIMMs\n");
+				break;
+		case DDR_INIT_FAILED_DIMM_SPD_ERR:
+				fprintf(stdout, "DDR INIT FAILED. CH:%d DIMM:%c is SPD ERROR\n",
+					ddr_init_status_out->init_status.failed_channel_id,
+					ddr_init_status_out->init_status.failed_dimm_silk_screen);
+
+				fprintf(stdout, "RECOVERY REMEDY: REPLACE CH:%d DIMM:%c\n",
+					ddr_init_status_out->init_status.failed_channel_id,
+					ddr_init_status_out->init_status.failed_dimm_silk_screen);
+				break;
+		case DDR_INIT_FAILED_DIMM_MPN_DISTINCT:
+				fprintf(stdout, "DDR INIT FAILED. CH:%d DIMM:%c is MPN MISS MATCH\n",
+					ddr_init_status_out->init_status.failed_channel_id,
+					ddr_init_status_out->init_status.failed_dimm_silk_screen);
+
+				fprintf(stdout, "RECOVERY REMEDY: PLUG IN SAME MPN DIMMS ON CH:%d\n",
+					ddr_init_status_out->init_status.failed_channel_id);
+				break;
+		case DDR_INIT_FAILED_TIMEOUT:
+				fprintf(stdout, "DDR INIT FAILED. CH:%d is MC or PI INIT TIMEOUT\n",
+					ddr_init_status_out->init_status.failed_channel_id);
+
+				fprintf(stdout, "RECOVERY REMEDY: REPLACE DIMMS ON CH:%d\n",
+					ddr_init_status_out->init_status.failed_channel_id);
 				break;
 		default:
 				fprintf(stdout, "DDR INIT STATUS invalid\n");


### PR DESCRIPTION
Summary:
This is in the sync with diff D76507882 and T229018316. Introduced new error return status in DDR INIT phase.
  DDR_INIT_FAILED_DIMM_SPD_ERR = -4,
  DDR_INIT_FAILED_DIMM_MPN_DISTINCT = -5,
  DDR_INIT_FAILED_TIMEOUT = -6,
Hence the mailBox command "ddr-init-status" updated to return same appropriate error messages which were returned in DDR INIT stage.

And a change made in code where the format specifier in print commands for health_counters was changed from %d to %u. This change was done to avoid printing negative values in mailbox output, which can rarely occur if the downline QSPI memory corrupts the data.

Test Plan:
1.
[00:00:16.580,000] ddr_init: DDR1 PI Done timeout
[00:00:19.936,000] dimm_info: Total DDR Size : 0 GB  DDR init did not pass, status = -6

DDR INIT FAILED. CH:1 is MC or PI INIT TIMEOUT
RECOVERY REMEDY: REPLACE DIMMS ON CH:1

2.
[00:00:02.805,000] ddr_init: [ERR] DIMM MPN mismatch detected at CH0 DIMM[1]! [00:00:02.817,000] dimm_info: Total DDR Size : 0 GB  DDR init did not pass, status = -5

DDR INIT FAILED. CH:0 DIMM:A is MPN MISS MATCH
RECOVERY REMEDY: PLUG IN SAME MPN DIMMS ON CH:0

3.
[00:00:02.818,000] ddr_init: [ERR] DIMM MPN mismatch detected at CH1 DIMM[3]! [00:00:02.825,000] dimm_info: Total DDR Size : 0 GB  DDR init did not pass, status = -5

DDR INIT FAILED. CH:1 DIMM:D is MPN MISS MATCH
RECOVERY REMEDY: PLUG IN SAME MPN DIMMS ON CH:1

4.
[00:00:19.928,000] ddr_init: DDR0 PI Done timeout

DDR INIT FAILED. CH:0 is MC or PI INIT TIMEOUT
RECOVERY REMEDY: REPLACE DIMMS ON CH:0

Reviewers:

Subscribers:

Tasks:

Tags: