### PR TITLE
Vistara  Mailbox command to read coredump info. from qspi

### DIFF
--- a/cxl/builtin.h
+++ b/cxl/builtin.h
@@ -176,5 +176,6 @@ int cmd_ddr_threshold_set(int argc, const char **argv, struct cxl_ctx *ctx);
 int cmd_ddr_threshold_get(int argc, const char **argv, struct cxl_ctx *ctx);
 int cmd_cxl_threshold_set(int argc, const char **argv, struct cxl_ctx *ctx);
 int cmd_cxl_threshold_get(int argc, const char **argv, struct cxl_ctx *ctx);
+int cmd_get_coredump(int argc, const char **argv, struct cxl_ctx *ctx);
 
 #endif /* _CXL_BUILTIN_H_ */

--- a/cxl/cxl.c
+++ b/cxl/cxl.c
@@ -232,6 +232,7 @@ static struct cmd_struct commands[] = {
 	{ "ddr-thres-get", .c_fn = cmd_ddr_threshold_get },
 	{ "cxl-thres-set", .c_fn = cmd_cxl_threshold_set },
 	{ "cxl-thres-get", .c_fn = cmd_cxl_threshold_get },
+	{ "get-coredump", .c_fn = cmd_get_coredump },
 };
 
 int main(int argc, const char **argv)

--- a/cxl/lib/libcxl.sym
+++ b/cxl/lib/libcxl.sym
@@ -233,4 +233,5 @@ global:
     cxl_memdev_ddr_threshold_get;
     cxl_memdev_cxl_threshold_set;
     cxl_memdev_cxl_threshold_get;
+    cxl_memdev_get_coredump;
 } LIBCXL_3;

--- a/cxl/libcxl.h
+++ b/cxl/libcxl.h
@@ -302,6 +302,7 @@ int cxl_memdev_ddr_threshold_set(struct cxl_memdev *memdev, u16 corr_err_thresho
 int cxl_memdev_ddr_threshold_get(struct cxl_memdev *memdev);
 int cxl_memdev_cxl_threshold_set(struct cxl_memdev *memdev, u16 corr_err_threshold_cnt, u16 corr_err_time_limit, u16 uncorr_err_threshold_cnt, u16 uncorr_err_time_limit);
 int cxl_memdev_cxl_threshold_get(struct cxl_memdev *memdev);
+int cxl_memdev_get_coredump(struct cxl_memdev *memdev);
 
 #define cxl_memdev_foreach(ctx, memdev) \
         for (memdev = cxl_memdev_get_first(ctx); \

--- a/cxl/memdev.c
+++ b/cxl/memdev.c
@@ -2185,6 +2185,11 @@ static const struct option cmd_trigger_coredump_options[] = {
   OPT_END(),
 };
 
+static const struct option cmd_get_coredump_options[] = {
+  BASE_OPTIONS(),
+  OPT_END(),
+};
+
 static struct _ddr_err_inj_en_params {
 	u32 ddr_id;
 	u32 err_type;
@@ -4487,6 +4492,17 @@ static int action_cmd_trigger_coredump(struct cxl_memdev *memdev,
         return cxl_memdev_trigger_coredump(memdev);
 }
 
+static int action_cmd_get_coredump(struct cxl_memdev *memdev,
+                                    struct action_context *actx)
+{
+    if (cxl_memdev_is_active(memdev)) {
+        fprintf(stderr, "%s: memdev active, abort get_coredump\n",
+                cxl_memdev_get_devname(memdev));
+        return -EBUSY;
+    }
+
+    return cxl_memdev_get_coredump(memdev);
+}
 static int action_cmd_ddr_err_inj_en(struct cxl_memdev *memdev,
 				      struct action_context *actx)
 {
@@ -6106,6 +6122,14 @@ int cmd_trigger_coredump(int argc, const char **argv, struct cxl_ctx *ctx)
       "cxl trigger-coredump <mem0> [<mem1>..<memN>] [<options>]");
 
   return rc >= 0 ? 0 : EXIT_FAILURE;
+}
+
+int cmd_get_coredump(int argc, const char **argv, struct cxl_ctx *ctx)
+{
+    int rc = memdev_action(argc, argv, ctx, action_cmd_get_coredump, cmd_get_coredump_options,
+        "cxl get-coredump <mem0> [<mem1>..<memN>] [<options>]");
+
+    return rc >= 0 ? 0 : EXIT_FAILURE;
 }
 
 int cmd_ddr_err_inj_en(int argc, const char **argv, struct cxl_ctx *ctx)


### PR DESCRIPTION
Summary:
	Mailbox command to Read coredump info. from qspi to a file in host machine over CXL interface

Test Plan:
  cxl get-coredump mem0 / mem1

  cxl trigger-coredump mem0
  cxl trigger-coredump mem1

  cxl get-coredump

Usage: cxl get-coredump <mem0> [<mem1>..<memN>] [<options>]

    -v, --verbose         turn on debug

Output:
	> TO CHECK IF THE COREDUMP IS GENERATED
	ls -lrt /tmp

Reviewers:

Subscribers:

Tasks:

Tags: