### PR TITLE
VISTARA : Update health-counters-get mailbox command to support json …

### DIFF
--- a/cxl/lib/private.h
+++ b/cxl/lib/private.h
@@ -96,6 +96,35 @@ struct cxl_cmd_get_health_info {
 	le32 pmem_errors;
 } __attribute__((packed));
 
+struct cxl_mbox_health_counters_get_out {
+        __le32 critical_over_temperature_exceeded;
+        __le32 power_on_events;
+        __le32 power_on_hours;
+        __le32 cxl_mem_link_crc_errors;
+        __le32 cxl_io_link_lcrc_errors;
+        __le32 cxl_io_link_ecrc_errors;
+        __le32 num_ddr_correctable_ecc_errors;
+        __le32 num_ddr_uncorrectable_ecc_errors;
+        __le32 link_recovery_events;
+        __le32 time_in_throttled;
+        __le32 over_temperature_warning_level_exceeded;
+        __le32 critical_under_temperature_exceeded;
+        __le32 under_temperature_warning_level_exceeded;
+        __le32 rx_retry_request;
+        __le32 rcmd_qs0_hi_threshold_detect;
+        __le32 rcmd_qs1_hi_threshold_detect;
+        __le32 num_pscan_correctable_ecc_errors;
+        __le32 num_pscan_uncorrectable_ecc_errors;
+        __le32 num_ddr_dimm0_correctable_ecc_errors;
+        __le32 num_ddr_dimm0_uncorrectable_ecc_errors;
+        __le32 num_ddr_dimm1_correctable_ecc_errors;
+        __le32 num_ddr_dimm1_uncorrectable_ecc_errors;
+        __le32 num_ddr_dimm2_correctable_ecc_errors;
+        __le32 num_ddr_dimm2_uncorrectable_ecc_errors;
+        __le32 num_ddr_dimm3_correctable_ecc_errors;
+        __le32 num_ddr_dimm3_uncorrectable_ecc_errors;
+}  __attribute__((packed));
+
 static inline int check_kmod(struct kmod_ctx *kmod_ctx)
 {
 	return kmod_ctx ? 0 : -ENXIO;

--- a/cxl/libcxl.h
+++ b/cxl/libcxl.h
@@ -167,7 +167,7 @@ int cxl_memdev_hbo_transfer_fw(struct cxl_memdev *memdev);
 int cxl_memdev_hbo_activate_fw(struct cxl_memdev *memdev);
 int cxl_memdev_health_counters_clear(struct cxl_memdev *memdev,
 	u32 bitmask);
-int cxl_memdev_health_counters_get(struct cxl_memdev *memdev);
+int cxl_memdev_health_counters_get(struct cxl_memdev *memdev, bool output_format);
 int cxl_memdev_hct_get_plat_param(struct cxl_memdev *memdev);
 int cxl_memdev_err_inj_hif_poison(struct cxl_memdev *memdev, u8 ch_id,
 	u8 duration, u8 inj_mode, u64 address);

--- a/cxl/memdev.c
+++ b/cxl/memdev.c
@@ -1609,9 +1609,16 @@ static const struct option cmd_health_counters_clear_options[] = {
 };
 
 
+static struct _output_format_params {
+  bool json_output;
+} output_format_params;
+
+#define OUTPUT_FORMAT_OPTIONS() \
+OPT_BOOLEAN('j', "json", &output_format_params.json_output, "output prints in json format")
 
 static const struct option cmd_health_counters_get_options[] = {
   BASE_OPTIONS(),
+  OUTPUT_FORMAT_OPTIONS(),
   OPT_END(),
 };
 
@@ -3572,7 +3579,7 @@ static int action_cmd_health_counters_get(struct cxl_memdev *memdev, struct acti
     return -EBUSY;
   }
 
-  return cxl_memdev_health_counters_get(memdev);
+  return cxl_memdev_health_counters_get(memdev, output_format_params.json_output);
 }
 
 static int action_cmd_hct_get_plat_param(struct cxl_memdev *memdev, struct action_context *actx)

--- a/util/json.h
+++ b/util/json.h
@@ -56,6 +56,10 @@ struct json_object *util_dimm_firmware_to_json(struct ndctl_dimm *dimm,
 		unsigned long flags);
 struct json_object *util_region_capabilities_to_json(struct ndctl_region *region);
 struct cxl_memdev;
+struct cxl_mbox_health_counters_get_out;
 struct json_object *util_cxl_memdev_to_json(struct cxl_memdev *memdev,
 		unsigned long flags);
+struct json_object *util_cxl_memdev_health_counters_to_json(
+		const char *devname,
+		struct cxl_mbox_health_counters_get_out *health_counters);
 #endif /* __NDCTL_JSON_H__ */


### PR DESCRIPTION
…output when opted

Summary:
      Added json format output support to health-counters-get mailbox command when queried
      with "-j" or "--json" option.

Test Plan:
      cxl health-counters-get mem0 --json
      cxl health-counters-get mem1 -j
      cxl health-counters-get all --json

usage: cxl health_counters_get <mem0> [<mem1>..<memN>] [<options>]

      -v, --verbose         turn on debug
      -j, --json            output prints in json format

Output:
{
  "memdev":"mem1",
  "critical_over_temperature_exceeded":0,
  "over_temperature_warning_level_exceeded":0,
  "critical_under_temperature_exceeded":0,
  "under_temperature_warning_level_exceeded":0,
  "power_on_events":67,
  "power_on_hours":4031,
  "cxl_mem_link_crc_errors":0,
  "cxl_io_link_lcrc_errors":0,
  "cxl_io_link_ecrc_errors":0,
  "num_ddr_correctable_ecc_errors":0,
  "num_ddr_uncorrectable_ecc_errors":0,
  "link_recovery_events":0,
  "time_in_throttled":0,
  "rx_retry_request":0,
  "rcmd_qs0_hi_threshold_detect":0,
  "rcmd_qs1_hi_threshold_detect":0,
  "num_pscan_correctable_ecc_errors":0,
  "num_pscan_uncorrectable_ecc_errors":0,
  "num_ddr_dimm0_correctable_ecc_errors":0,
  "num_ddr_dimm0_uncorrectable_ecc_errors":0,
  "num_ddr_dimm1_correctable_ecc_errors":0,
  "num_ddr_dimm1_uncorrectable_ecc_errors":0,
  "num_ddr_dimm2_correctable_ecc_errors":0,
  "num_ddr_dimm2_uncorrectable_ecc_errors":0,
  "num_ddr_dimm3_correctable_ecc_errors":0,
  "num_ddr_dimm3_uncorrectable_ecc_errors":0
}
Reviewers:

Subscribers:

Tasks: T224200834

Tags: