### PR TITLE
[Vistara] Rate Limit Config structure align

### DIFF
--- a/cxl/lib/libcxl.c
+++ b/cxl/lib/libcxl.c
@@ -15902,8 +15902,8 @@ out:
 // struct to hold threshold count and time limit in minutes
 struct rlc_cfg {
     u16 corr_err_threshold_cnt;
-    u16 corr_err_time_limit;
     u16 uncorr_err_threshold_cnt;
+    u16 corr_err_time_limit;
     u16 uncorr_err_time_limit;
 } __attribute__((packed));
 

--- a/cxl/memdev.c
+++ b/cxl/memdev.c
@@ -2491,8 +2491,8 @@ static const struct option cmd_cxl_ddr_irq_enable_set_options[] = {
 // struct to hold threshold count and time limit in minutes
 struct _rlc_cfg {
   u32 corr_err_threshold_cnt;
-  u32 corr_err_time_limit;
   u32 uncorr_err_threshold_cnt;
+  u32 corr_err_time_limit;
   u32 uncorr_err_time_limit;
 } __attribute__((packed)) rlc_cfg;
 


### PR DESCRIPTION
    Summary:
    This is a fix to align structure of mailbox rlc_cfg with Vistara FW structure.
    This follows structure order to hold threshold count in value and time limit in minutes
    corr_err_threshold_cnt
    uncorr_err_threshold_cnt
    corr_err_time_limit
    uncorr_err_time_limit

    Test Plan:
    Get IRQ status CLI:
    cxl cxl-ddr-irq-status-get mem0
    Output:
    IRQ Status:
      CXL Correctable IRQ is enabled
      CXL Uncorrectable IRQ is enabled
      CXL Configuration IRQ is enabled
      DDR[0] IRQ is enabled
      DDR[1] IRQ is enabled

    Enable IRQ CLI:
    cxl cxl-ddr-irq-enable-set mem0 -i 5
    Output:
    Enable IRQ line 5

    Get Threshold count and Time limit for DDR0 and DDR1 CLI:
    cxl ddr-thres-get mem0
    Output:
      Correctable error: threshold count 100, time limit 60
      Uncorrectable error: threshold count 100, time limit 60

    Set Threshold count and Time limit for DDR0 and DDR1 CLI:
    cxl ddr-thres-set mem0 -c 5 -t 2 -u 6 -l 3
    Output:
      Correctable error: threshold count 5, time limit 2
      Uncorrectable error: threshold count 6, time limit 3

    Get Threshold count and Time limit for CXL CLI:
    cxl cxl-thres-get mem0
    Output:
      Correctable error: threshold count 100, time limit 60
      Uncorrectable error: threshold count 100, time limit 60

    Set Threshold count and Time limit for CXL CLI:
    cxl cxl-thres-set mem0 -c 7 -t 4 -u 8 -l 5
    Output:
      Correctable error: threshold count 7, time limit 4
      Uncorrectable error: threshold count 8, time limit 5

    Reviewers:

    Subscribers:

    Tasks:

    Tags:
    
Signed-off-by: balajhi-dn <neelakanbalajhi@meta.com>