### PR TITLE
VISTARA : fix libcxl json library dependency issue

### DIFF
--- a/cxl/lib/Makefile.am
+++ b/cxl/lib/Makefile.am
@@ -13,11 +13,16 @@ libcxl_la_SOURCES =\
 	../../util/sysfs.h \
 	../../util/log.c \
 	../../util/log.h \
+	../../util/json.c \
+	../../util/json.h \
 	libcxl.c
 
 libcxl_la_LIBADD =\
+	$(JSONC_LIBS) \
 	$(UUID_LIBS) \
 	$(KMOD_LIBS)
+
+libcxl_la_LIBADD += $(JSON_LIBS)
 
 EXTRA_DIST += libcxl.sym
 


### PR DESCRIPTION
Summary:
         Updated cx/lib/Makefile.am for json and jsonc lib dependency issues.

Test Plan:
         make and make check must work without any issues.

Output:

Reviewers:

Subscribers:

Tasks: T224200834

Tags: